### PR TITLE
simplify checks for existent files/dirs by using `mkdir --parents` to ig...

### DIFF
--- a/mailnag_config
+++ b/mailnag_config
@@ -1,18 +1,10 @@
 #!/bin/bash
 LIB_DIR=./Mailnag
 
-CONFIG_HOME=$XDG_CONFIG_HOME
-if [ "$CONFIG_HOME" == "" ]; then
-	CONFIG_HOME="$HOME/.config"
-fi
-config_dir="$CONFIG_HOME/mailnag"
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/mailnag"
 
-if [ ! -d "$config_dir" ]; then
-	mkdir --parents "$config_dir"
-fi
-if [ -f "$config_dir/mailnag_config.log" ]; then
-	rm "$config_dir/mailnag_config.log"
-fi
+mkdir --parents "$config_dir"
+rm --force "$config_dir/mailnag_config.log"
 
 cd $(dirname $(readlink -f $0))
 
@@ -23,9 +15,7 @@ if [ $? -eq 0 ]; then
 	if [ -f "$config_dir/mailnag.pid" ]; then
 		kill $(cat "$config_dir/mailnag.pid") 2> /dev/null
 	fi
-	if [ -f "$config_dir/mailnag.log" ]; then
-		rm "$config_dir/mailnag.log"
-	fi
+	rm --force "$config_dir/mailnag.log"
 	python $LIB_DIR/mailnag.py >> "$config_dir/mailnag.log" 2>&1 &
 else
 	echo mailnag-config discarded


### PR DESCRIPTION
...nore already existing directories and `rm --force` to ignore non-existent files.
