### PR TITLE
Make sure creating the connection succeeded

### DIFF
--- a/Mailnag/daemon/idler.py
+++ b/Mailnag/daemon/idler.py
@@ -71,7 +71,8 @@ class Idler(object):
 					# connection has been reset by provider -> reopen
 					print "Idler thread for account '%s' reconnected" % self._account.name
 					self._conn = self._account.get_connection(use_existing = False)
-					self._select(self._conn, self._account.folder)
+					if self._conn != None:
+						self._select(self._conn, self._account.folder)
 				
 				if not self._event.isSet():
 					self._needsync = True


### PR DESCRIPTION
I use mailnag on my laptop and I frequently suspend it. Somehow mailnag crashes after a resume because self._conn in idler.py is None. I think this patch fixes it because account._get_connection can return None in certain conditions.
