### PR TITLE
Mailnag autostart file misnamed/misplaced

### DIFF
--- a/Mailnag/configuration/configwindow.py
+++ b/Mailnag/configuration/configwindow.py
@@ -232,7 +232,7 @@ class ConfigWindow:
 		autostart_folder = os.path.join(bd.xdg_config_home, "autostart")
 		if not os.path.exists(autostart_folder):
 			os.makedirs(autostart_folder)
-		autostart_file = autostart_folder + "mailnag.desktop"
+		autostart_file = autostart_folder + "/" + "mailnag.desktop"
 		f = open(autostart_file, 'w') # create file
 		f.write(content)
 		f.close()


### PR DESCRIPTION
I'm not sure if this bug first surfaced in 0.5 or 0.5.1, but I've noticed recently that Mailnag is no longer autostarted when I login to gnome shell. Turns out that the autostart file is no longer placed in ~/.config/autostart/mailnag.desktop as with version 0.4, but placed and named as ~/.config/autostartmailnag.desktop (missing a slash, hence why Mailnag is not starting automatically at login; it should be placed in ~/.config/autostart/, not ~/.config).

Test case with version 0.5.1:

```
$ file .config/autostartmailnag.desktop 
.config/autostartmailnag.desktop: ASCII text
$ rm .config/autostartmailnag.desktop 
$ file .config/autostartmailnag.desktop 
.config/autostartmailnag.desktop: ERROR: cannot open `.config/autostartmailnag.desktop' (No such file or directory)
$ mailnag_config 
$ file .config/autostartmailnag.desktop 
.config/autostartmailnag.desktop: ASCII text
```

Pull request is a quick and dirty fix that works, but as you can probably tell, I'm not really a python coder...there's probably a cleaner way to fix this, but you get the idea. ;)
