### PR TITLE
use STARTTLS if offered

### DIFF
--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -153,7 +153,8 @@ class Account:
 					conn = imaplib.IMAP4(self.server)
 				else:
 					conn = imaplib.IMAP4(self.server, int(self.port))
-			
+				if 'STARTTLS' in conn.capabilities:
+					conn.starttls()
 			if self.oauth2string != '':
 				conn.authenticate('XOAUTH2', lambda x: self.oauth2string)
 			else:


### PR DESCRIPTION
This is a quick fix for #99 
If the server offers STARTTLS in CAPABILITIES we use it. (Providing a config option may be better, but I'm new to python and this works for me)