### PR TITLE
Added a sufficient Category definition to mailnag-config.desktop

### DIFF
--- a/data/mailnag-config.desktop
+++ b/data/mailnag-config.desktop
@@ -9,6 +9,6 @@ Exec=/usr/bin/mailnag-config
 Icon=mailnag
 Terminal=false
 Type=Application
-Categories=Network;
+Categories=Network;Email;
 StartupNotify=false
 X-AppStream-Ignore=true


### PR DESCRIPTION
https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories#Network requires a sub-category according to the FreeDesktop standards and this is enforced by a failing build check. For https://build.opensuse.org/request/show/397337 I changed this with an RPM macro, because patches won't apply cleanly to this file after recent changes since release 1.2.0