### PR TITLE
remove obsolete dep on libgtk-3-bin

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,6 @@ Depends:
  gir1.2-gst-plugins-base-1.0 (>= 1.2.0),
  gir1.2-gtk-3.0 (>= 3.6.4),
  gir1.2-notify-0.7 (>= 0.7.6),
- libgtk-3-bin (>= 3.6.4),
  python-dbus (>= 1.0.0),
  python-gobject (>= 3.2.0),
  python-xdg,


### PR DESCRIPTION
Prompted by Debian [#825450](https://bugs.debian.org/825450)

I took a quick look through mailnag and I don't think it actually makes use of any of the binaries provided by [libgtk-3-bin](https://packages.debian.org/sid/amd64/libgtk-3-bin/filelist), nor is there a call to gtk-update-icon-cache anywhere in the code. Does the Debian package actually need a dependency on libgtk-3-bin, or can it be dropped? The other python/gir bindings that are already listed as dependencies are enough to pull in anything gtk-related.