### PR TITLE
fix non-ascii folder names encoding in the configuration menu

### DIFF
--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -26,8 +26,8 @@
 import re
 import poplib
 import logging
+import json
 import Mailnag.common.imaplib2 as imaplib
-from Mailnag.common.utils import splitstr
 
 account_defaults = {
 	'enabled'			: '0',
@@ -39,7 +39,7 @@ account_defaults = {
 	'ssl'				: '1',
 	'imap'				: '1',	
 	'idle'				: '1',
-	'folder'			: ''
+	'folder'			: '[]'
 }
 
 CREDENTIAL_KEY = 'Mailnag password for %s://%s@%s'
@@ -276,7 +276,7 @@ class AccountManager:
 				ssl			= bool(int(	self._get_account_cfg(cfg, section_name, 'ssl')		))
 				imap		= bool(int(	self._get_account_cfg(cfg, section_name, 'imap')	))
 				idle		= bool(int(	self._get_account_cfg(cfg, section_name, 'idle')	))
-				folders		= splitstr(self._get_account_cfg(cfg, section_name, 'folder'), ',')
+				folders		= json.loads(self._get_account_cfg(cfg, section_name, 'folder'))
 
 				if self._credentialstore != None:
 					protocol = 'imap' if imap else 'pop'
@@ -329,7 +329,7 @@ class AccountManager:
 			cfg.set(section_name, 'ssl', int(acc.ssl))
 			cfg.set(section_name, 'imap', int(acc.imap))
 			cfg.set(section_name, 'idle', int(acc.idle))
-			cfg.set(section_name, 'folder', ', '.join(acc.folders))
+			cfg.set(section_name, 'folder', json.dumps(acc.folders))
 			
 			if self._credentialstore != None:
 				protocol = 'imap' if acc.imap else 'pop'

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -28,6 +28,7 @@ import poplib
 import logging
 import json
 import Mailnag.common.imaplib2 as imaplib
+from Mailnag.common.utils import splitstr
 
 account_defaults = {
 	'enabled'			: '0',
@@ -276,7 +277,11 @@ class AccountManager:
 				ssl			= bool(int(	self._get_account_cfg(cfg, section_name, 'ssl')		))
 				imap		= bool(int(	self._get_account_cfg(cfg, section_name, 'imap')	))
 				idle		= bool(int(	self._get_account_cfg(cfg, section_name, 'idle')	))
-				folders		= json.loads(self._get_account_cfg(cfg, section_name, 'folder'))
+				folders_str	= self._get_account_cfg(cfg, section_name, 'folder')
+				if re.match(r'^\[.*\]$', folders_str):
+					folders	= json.loads(folders_str)
+				else:
+					folders	= splitstr(folders_str, ',')
 
 				if self._credentialstore != None:
 					protocol = 'imap' if imap else 'pop'

--- a/Mailnag/common/mutf7.py
+++ b/Mailnag/common/mutf7.py
@@ -15,7 +15,7 @@ __license__ = "WTFPL v. 2"
 import base64
 import re
 
-ascii_codes = set(range(0x20,0x7e))
+ascii_codes = set(range(0x20,0x7f))
 
 def __get_ascii(text):
     pos = 0

--- a/Mailnag/common/mutf7.py
+++ b/Mailnag/common/mutf7.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+'''
+This awesome piece of code is intented to encode and decode modified UTF-7 
+(the one that is used for IMAP folder names)
+
+encode_mutf7(text) - to encode
+decode_mutf7(text) - to decode
+'''
+
+__author__ = "https://github.com/cheshire-mouse"
+__license__ = "WTFPL v. 2"
+
+import base64
+import re
+
+ascii_codes = set(range(0x20,0x7e))
+
+def __get_ascii(text):
+    pos = 0
+    for c in text:
+        code=ord(c)
+        if ord(c) not in ascii_codes :
+            break
+        pos += 1
+    return text[:pos].encode('ascii')
+
+def __remove_ascii(text):
+    pos = 0
+    for c in text:
+        if ord(c) not in ascii_codes :
+            break
+        pos += 1
+    return text[pos:]
+
+def __get_nonascii(text):
+    pos = 0
+    for c in text:
+        code=ord(c)
+        if ord(c) in ascii_codes :
+            break
+        pos += 1
+    return text[:pos]
+
+def __remove_nonascii(text):
+    pos = 0
+    for c in text:
+        if ord(c) in ascii_codes :
+            break
+        pos += 1
+    return text[pos:]
+
+def __encode_modified_utf7(text):
+    #modified base64 - good old base64 without padding characters (=)
+    result = base64.b64encode(text.encode('utf-16be')).rstrip('=')
+    result = result.replace('/',',')
+    result = '&' + result + '-'
+    return result
+
+def encode_mutf7(text):
+    result = ""
+    text = text.replace('&','&-')
+    while len(text) > 0:
+        result += __get_ascii(text)
+        text = __remove_ascii(text)
+        if len(text) > 0:
+            result += __encode_modified_utf7(__get_nonascii(text))
+            text = __remove_nonascii(text)
+    return result
+
+def __decode_modified_utf7(text):
+    if text == '&-':
+        return '&'
+    #remove leading & and trailing -
+    text_mb64 = text[1:-1]
+    text_b64 = text_mb64.replace(',','/')
+    #back to normal base64 with padding
+    while len(text_b64) % 4 != 0:
+        text_b64 += '='
+    text_u16 = base64.b64decode(text_b64)
+    result = text_u16.decode('utf-16be')
+    return result
+
+def decode_mutf7(text):
+    rxp = re.compile('&[^&-]*-')
+    match = rxp.search(text)
+    while ( match ):
+        encoded_text = match.group(0)
+        decoded_text = __decode_modified_utf7(encoded_text)
+        text = rxp.sub(decoded_text,text, count=1)
+        match = rxp.search(text)
+    result = text
+    return result
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
+

--- a/Mailnag/configuration/accountdialog.py
+++ b/Mailnag/configuration/accountdialog.py
@@ -31,6 +31,7 @@ from Mailnag.common.dist_cfg import PACKAGE_NAME
 from Mailnag.common.i18n import _
 from Mailnag.common.utils import get_data_file, splitstr
 from Mailnag.common.accounts import Account
+from Mailnag.common import mutf7
 
 IDX_GMAIL	= 0
 IDX_GMX		= 1
@@ -170,7 +171,7 @@ class AccountDialog:
 		folders = []
 		for row in self._liststore_folders:
 			if row[0]:
-				folders.append(row[1])
+				folders.append(mutf7.encode_mutf7(row[1].decode('utf-8')))
 		return folders
 	
 	
@@ -282,7 +283,7 @@ class AccountDialog:
 						if f in self._acc.folders:
 							enabled = True
 							self._selected_folder_count += 1
-						row = [enabled, f]
+						row = [enabled, mutf7.decode_mutf7(f)]
 						self._liststore_folders.append(row)
 					
 					# Enable the push checkbox in case a remote folder wasn't found 


### PR DESCRIPTION
So, this is definitely GPL-compatible solution. Drawback is that it is made from scratch and based on my understanding of IMAP RFC.
The other problem is that folders are saved as comma separated string. And if encoded folder name contains comma it will break the program. So I switched to JSON