### PR TITLE
IMAP and POP3 specific code moved to backend classes.

### DIFF
--- a/Mailnag/backends/__init__.py
+++ b/Mailnag/backends/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# __init__.py
+#
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+"""Backends to implement mail box specific functionality, like IMAP and POP3."""
+

--- a/Mailnag/backends/base.py
+++ b/Mailnag/backends/base.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+# base.py
+#
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+"""Interface and base implementation for mailbox backends."""
+
+from abc import ABCMeta, abstractmethod
+
+
+class MailboxBackend(object):
+	"""Interface for mailbox backends.
+
+	Mailbox backend implements access to the specific type of mailbox.
+	"""
+
+	__metaclass__ = ABCMeta
+
+	def __init__(self, **kw):
+		"""Constructor should accept any kind of backend specific
+		parameters.
+		"""
+
+	@abstractmethod
+	def open(self, reopen):
+		"""Opens the mailbox.
+		If reopen is true, mailbox should first be closed and then opened.
+		"""
+		raise NotImplementedError
+
+	@abstractmethod
+	def close(self):
+		"""Closes the mailbox."""
+		raise NotImplementedError
+
+	@abstractmethod
+	def is_open(self):
+		"""Returns true if mailbox is open."""
+		raise NotImplementedError
+
+	@abstractmethod
+	def list_messages(self):
+		"""Lists unseen messages from the mailbox for this account.
+		Yields tuples (folder, message) for every message.
+		"""
+		raise NotImplementedError
+
+	@abstractmethod
+	def request_folders(self):
+		"""Returns list of folder names available in the mailbox.
+		Returns an empty list if mailbox does not support folders.
+		"""
+		raise NotImplementedError
+
+	@abstractmethod
+	def notify_next_change(self, callback=None, timeout=None):
+		"""Asks mailbox to notify next change.
+		Callback is called when new mail arrives or a mail is removed.
+		This may raise an exception if mailbox does not support
+		notifications.
+		"""
+		raise NotImplementedError
+
+	@abstractmethod
+	def cancel_notifications(self):
+		"""Cancels notifications.
+		This may raise an exception if mailbox does not support
+		notifications.
+		"""
+		raise NotImplementedError
+

--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -20,15 +20,20 @@
 # MA 02110-1301, USA.
 #
 
+"""Implementation for IMAP mailbox connection."""
+
 import email
 import logging
 import re
+
+from Mailnag.backends.base import MailboxBackend
 import Mailnag.common.imaplib2 as imaplib
 from Mailnag.common.imaplib2 import AUTH
 
-class IMAPBackend:
+
+class IMAPBackend(MailboxBackend):
 	"""Implementation of IMAP mail boxes."""
-	
+
 	def __init__(self, name = '', user = '', password = '', oauth2string = '',
 				 server = '', port = '', ssl = True, folders = []):
 		self.name = name

--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -34,7 +34,7 @@ import Mailnag.common.imaplib2 as imaplib
 from Mailnag.common.imaplib2 import AUTH
 
 
-class IMAPBackend(MailboxBackend):
+class IMAPMailboxBackend(MailboxBackend):
 	"""Implementation of IMAP mail boxes."""
 
 	def __init__(self, name = '', user = '', password = '', oauth2string = '',

--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -84,6 +84,11 @@ class ImapBackend:
 		return self._conn
 
 
+	def close(self):
+		self._conn.close()
+		self._conn.logout()
+
+
 	def has_connection(self):
 		return (self._conn != None) and \
 				(self._conn.state != imaplib.LOGOUT) and \

--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -2,7 +2,10 @@
 #
 # imap.py
 #
+# Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
 # Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+# Copyright 2016 Thomas Haider <t.haider@deprecate.de>
+# Copyright 2011 Ralf Hersel <ralf.hersel@gmx.net>#
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -2,10 +2,7 @@
 #
 # imap.py
 #
-# Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
 # Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
-# Copyright 2016 Thomas Haider <t.haider@deprecate.de>
-# Copyright 2011 Ralf Hersel <ralf.hersel@gmx.net>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# imap.py
+#
+# Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+# Copyright 2016 Thomas Haider <t.haider@deprecate.de>
+# Copyright 2011 Ralf Hersel <ralf.hersel@gmx.net>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+class ImapBackend:
+	pass
+

--- a/Mailnag/backends/pop3.py
+++ b/Mailnag/backends/pop3.py
@@ -20,11 +20,16 @@
 # MA 02110-1301, USA.
 #
 
+"""Implementation for POP3 mailbox connection."""
+
 import email
 import logging
 import poplib
 
-class POP3Backend:
+from Mailnag.backends.base import MailboxBackend
+
+
+class POP3Backend(MailboxBackend):
 	"""Implementation of POP3 mail boxes."""
 	
 	def __init__(self, name = '', user = '', password = '', oauth2string = '',

--- a/Mailnag/backends/pop3.py
+++ b/Mailnag/backends/pop3.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# imap.py
+# pop3.py
 #
+# Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
 # Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+# Copyright 2016 Thomas Haider <t.haider@deprecate.de>
+# Copyright 2011 Ralf Hersel <ralf.hersel@gmx.net>#
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/Mailnag/backends/pop3.py
+++ b/Mailnag/backends/pop3.py
@@ -120,9 +120,9 @@ class POP3Backend:
 
 
 	def notify_next_change(self, callback=None, timeout=None):
-		raise NotImplemented("POP3 does not support notifications")
+		raise NotImplementedError("POP3 does not support notifications")
 
 
 	def cancel_notifications(self):
-		raise NotImplemented("POP3 does not support notifications")
+		raise NotImplementedError("POP3 does not support notifications")
 

--- a/Mailnag/backends/pop3.py
+++ b/Mailnag/backends/pop3.py
@@ -23,6 +23,68 @@
 # MA 02110-1301, USA.
 #
 
+import logging
+import poplib
+
 class Pop3Backend:
-	pass
+	"""Implementation of POP3 mail boxes."""
+	
+	def __init__(self, name = '', user = '', password = '', oauth2string = '',
+				 server = '', port = '', ssl = True):
+		self.name = name
+		self.user = user
+		self.password = password
+		self.oauth2string = oauth2string
+		self.server = server
+		self.port = port
+		self.ssl = ssl # bool
+		self._conn = None
+
+
+	def get_connection(self, use_existing):
+		# try to reuse existing connection
+		if use_existing and self.has_connection():
+			return self._conn
+		
+		self._conn = conn = None
+		
+		try:
+			if self.ssl:
+				if self.port == '':
+					conn = poplib.POP3_SSL(self.server)
+				else:
+					conn = poplib.POP3_SSL(self.server, int(self.port))
+			else:
+				if self.port == '':
+					conn = poplib.POP3(self.server)
+				else:
+					conn = poplib.POP3(self.server, int(self.port))
+				
+				# TODO : Use STARTTLS when Mailnag has been migrated to python 3
+				# (analogous to get_connection in imap backend).
+				logging.warning("Using unencrypted connection for account '%s'" % self.name)
+				
+			conn.getwelcome()
+			conn.user(self.user)
+			conn.pass_(self.password)
+			
+			self._conn = conn
+		except:
+			try:
+				if conn != None:
+					conn.quit()
+			except:	pass
+			raise # re-throw exception
+		
+		return self._conn
+
+
+	def has_connection(self):
+		return (self._conn != None) and \
+				('sock' in self._conn.__dict__)
+	
+
+	def request_folders(self):
+		lst = []
+		return lst
 

--- a/Mailnag/backends/pop3.py
+++ b/Mailnag/backends/pop3.py
@@ -27,7 +27,7 @@ import email
 import logging
 import poplib
 
-class Pop3Backend:
+class POP3Backend:
 	"""Implementation of POP3 mail boxes."""
 	
 	def __init__(self, name = '', user = '', password = '', oauth2string = '',
@@ -42,10 +42,10 @@ class Pop3Backend:
 		self._conn = None
 
 
-	def get_connection(self, use_existing):
+	def open(self, reopen):
 		# try to reuse existing connection
-		if use_existing and self.has_connection():
-			return self._conn
+		if not reopen and self.is_open():
+			return
 		
 		self._conn = conn = None
 		
@@ -84,7 +84,7 @@ class Pop3Backend:
 		self._conn.quit()
 
 
-	def has_connection(self):
+	def is_open(self):
 		return (self._conn != None) and \
 				('sock' in self._conn.__dict__)
 
@@ -117,4 +117,12 @@ class Pop3Backend:
 	def request_folders(self):
 		lst = []
 		return lst
+
+
+	def notify_next_change(self, callback=None, timeout=None):
+		raise NotImplemented("POP3 does not support notifications")
+
+
+	def cancel_notifications(self):
+		raise NotImplemented("POP3 does not support notifications")
 

--- a/Mailnag/backends/pop3.py
+++ b/Mailnag/backends/pop3.py
@@ -32,7 +32,7 @@ import poplib
 from Mailnag.backends.base import MailboxBackend
 
 
-class POP3Backend(MailboxBackend):
+class POP3MailboxBackend(MailboxBackend):
 	"""Implementation of POP3 mail boxes."""
 	
 	def __init__(self, name = '', user = '', password = '', oauth2string = '',

--- a/Mailnag/backends/pop3.py
+++ b/Mailnag/backends/pop3.py
@@ -79,6 +79,9 @@ class Pop3Backend:
 		return self._conn
 
 
+	def close(self):
+		self._conn.quit()
+
 	def has_connection(self):
 		return (self._conn != None) and \
 				('sock' in self._conn.__dict__)

--- a/Mailnag/backends/pop3.py
+++ b/Mailnag/backends/pop3.py
@@ -2,10 +2,7 @@
 #
 # imap.py
 #
-# Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
 # Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
-# Copyright 2016 Thomas Haider <t.haider@deprecate.de>
-# Copyright 2011 Ralf Hersel <ralf.hersel@gmx.net>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/Mailnag/backends/pop3.py
+++ b/Mailnag/backends/pop3.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# imap.py
+#
+# Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+# Copyright 2016 Thomas Haider <t.haider@deprecate.de>
+# Copyright 2011 Ralf Hersel <ralf.hersel@gmx.net>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+class Pop3Backend:
+	pass
+

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -74,6 +74,10 @@ class Account:
 			return self._get_POP3_connection(use_existing)
 	
 	
+	def close(self):
+		self.backend.close()
+	
+	
 	# Indicates whether the account 
 	# holds an active existing connection.
 	# Note: this method only indicates if the 

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -28,6 +28,8 @@ import poplib
 import logging
 import json
 import Mailnag.common.imaplib2 as imaplib
+from Mailnag.backends.imap import ImapBackend
+from Mailnag.backends.pop3 import Pop3Backend
 from Mailnag.common.utils import splitstr
 
 account_defaults = {
@@ -50,7 +52,7 @@ CREDENTIAL_KEY = 'Mailnag password for %s://%s@%s'
 #
 class Account:
 	def __init__(self, enabled = False, name = '', user = '', \
-		password = '', oauth2string = '', server = '', port = '', ssl = True, imap = True, idle = True, folders = []):
+		password = '', oauth2string = '', server = '', port = '', ssl = True, imap = True, idle = True, folders = [], backend = None):
 		
 		self.enabled = enabled # bool
 		self.name = name
@@ -63,6 +65,7 @@ class Account:
 		self.imap = imap # bool		
 		self.idle = idle # bool
 		self.folders = folders
+		self.backend = backend
 		self._conn = None
 
 
@@ -287,7 +290,12 @@ class AccountManager:
 					protocol = 'imap' if imap else 'pop'
 					password = self._credentialstore.get(CREDENTIAL_KEY % (protocol, user, server))
 				
-				acc = Account(enabled, name, user, password, '', server, port, ssl, imap, idle, folders)
+				if imap:
+					backend = ImapBackend()
+				else:
+					bakcend = Pop3Backend()
+				
+				acc = Account(enabled, name, user, password, '', server, port, ssl, imap, idle, folders, backend)
 				self._accounts.append(acc)
 
 			i = i + 1

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -91,8 +91,12 @@ class Account:
 			return self._has_IMAP_connection()
 		else:
 			return self._has_POP3_connection()
-	
-	
+
+
+	def list_messages(self):
+		return self.backend.list_messages()
+
+
 	# Requests folder names (list) from a server.
 	# Relevant for IMAP accounts only.
 	# Returns an empty list when used on POP3 accounts.

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -68,10 +68,8 @@ class Account:
 
 
 	def get_connection(self, use_existing = False): # get email server connection
-		if self.imap:
-			return self._get_IMAP_connection(use_existing)
-		else:
-			return self._get_POP3_connection(use_existing)
+		self._conn = self.backend.get_connection(use_existing)
+		return self._conn
 	
 	
 	def close(self):
@@ -87,10 +85,7 @@ class Account:
 	# was called multiple times (with use_existing 
 	# set to False).
 	def has_connection(self):
-		if self.imap:
-			return self._has_IMAP_connection()
-		else:
-			return self._has_POP3_connection()
+		return self.backend.has_connection()
 
 
 	def list_messages(self):
@@ -108,24 +103,6 @@ class Account:
 		# TODO : this id is not really unique...
 		return str(hash(self.user + self.server + ', '.join(self.folders)))
 	
-
-	def _has_IMAP_connection(self):
-		return self.backend.has_connection()
-	
-	
-	def _get_IMAP_connection(self, use_existing):
-		self._conn = self.backend.get_connection(use_existing)
-		return self._conn
-	
-	
-	def _has_POP3_connection(self):
-		return self.backend.has_connection()
-	
-	
-	def _get_POP3_connection(self, use_existing):
-		self._conn = self.backend.get_connection(use_existing)
-		return self._conn
-
 
 #
 # AccountManager class

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -5,6 +5,7 @@
 #
 # Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
 # Copyright 2016 Thomas Haider <t.haider@deprecate.de>
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
 # Copyright 2011 Ralf Hersel <ralf.hersel@gmx.net>
 #
 # This program is free software; you can redistribute it and/or modify

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -64,7 +64,6 @@ class Account:
 		self.idle = idle # bool
 		self.folders = folders
 		self.backend = backend
-		self._conn = None
 
 
 	def open(self, reopen = True):

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -27,8 +27,8 @@
 import re
 import logging
 import json
-from Mailnag.backends.imap import IMAPBackend
-from Mailnag.backends.pop3 import POP3Backend
+from Mailnag.backends.imap import IMAPMailboxBackend
+from Mailnag.backends.pop3 import POP3MailboxBackend
 from Mailnag.common.utils import splitstr
 
 account_defaults = {
@@ -200,9 +200,9 @@ class AccountManager:
 					password = self._credentialstore.get(CREDENTIAL_KEY % (protocol, user, server))
 				
 				if imap:
-					backend = IMAPBackend(name, user, password, '', server, port, ssl, folders)
+					backend = IMAPMailboxBackend(name, user, password, '', server, port, ssl, folders)
 				else:
-					backend = POP3Backend(name, user, password, '', server, port, ssl)
+					backend = POP3MailboxBackend(name, user, password, '', server, port, ssl)
 				
 				acc = Account(enabled, name, user, password, '', server, port, ssl, imap, idle, folders, backend)
 				self._accounts.append(acc)

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -92,6 +92,19 @@ class Account:
 		return self.backend.list_messages()
 
 
+	# TODO: Temporarily here. Remove when no needed.
+	def select(self):
+		self.backend.select()
+
+
+	def notify_next_change(self, callback=None, timeout=None):
+		self.backend.notify_next_change(callback, timeout)
+
+
+	def cancel_notifications(self):
+		self.backend.cancel_notifications()
+
+
 	# Requests folder names (list) from a server.
 	# Relevant for IMAP accounts only.
 	# Returns an empty list when used on POP3 accounts.

--- a/Mailnag/configuration/accountdialog.py
+++ b/Mailnag/configuration/accountdialog.py
@@ -27,8 +27,8 @@ gi.require_version('GLib', '2.0')
 
 from gi.repository import GObject, GLib, Gtk
 from thread import start_new_thread
-from Mailnag.backends.imap import ImapBackend
-from Mailnag.backends.pop3 import Pop3Backend
+from Mailnag.backends.imap import IMAPBackend
+from Mailnag.backends.pop3 import POP3Backend
 from Mailnag.common.dist_cfg import PACKAGE_NAME
 from Mailnag.common.i18n import _
 from Mailnag.common.utils import get_data_file, splitstr
@@ -171,9 +171,9 @@ class AccountDialog:
 		# Create backend
 		# TODO: This is duplicate code with AccountManager.
 		if acc.imap:
-			acc.backend = ImapBackend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl, acc.folders)
+			acc.backend = IMAPBackend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl, acc.folders)
 		else:
-			acc.backend = Pop3Backend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl)
+			acc.backend = POP3Backend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl)
 	
 	
 	def _get_selected_folders(self):

--- a/Mailnag/configuration/accountdialog.py
+++ b/Mailnag/configuration/accountdialog.py
@@ -4,6 +4,7 @@
 # accountdialog.py
 #
 # Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/Mailnag/configuration/accountdialog.py
+++ b/Mailnag/configuration/accountdialog.py
@@ -28,8 +28,8 @@ gi.require_version('GLib', '2.0')
 
 from gi.repository import GObject, GLib, Gtk
 from thread import start_new_thread
-from Mailnag.backends.imap import IMAPBackend
-from Mailnag.backends.pop3 import POP3Backend
+from Mailnag.backends.imap import IMAPMailboxBackend
+from Mailnag.backends.pop3 import POP3MailboxBackend
 from Mailnag.common.dist_cfg import PACKAGE_NAME
 from Mailnag.common.i18n import _
 from Mailnag.common.utils import get_data_file, splitstr
@@ -172,9 +172,9 @@ class AccountDialog:
 		# Create backend
 		# TODO: This is duplicate code with AccountManager.
 		if acc.imap:
-			acc.backend = IMAPBackend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl, acc.folders)
+			acc.backend = IMAPMailboxBackend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl, acc.folders)
 		else:
-			acc.backend = POP3Backend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl)
+			acc.backend = POP3MailboxBackend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl)
 	
 	
 	def _get_selected_folders(self):

--- a/Mailnag/configuration/accountdialog.py
+++ b/Mailnag/configuration/accountdialog.py
@@ -27,6 +27,8 @@ gi.require_version('GLib', '2.0')
 
 from gi.repository import GObject, GLib, Gtk
 from thread import start_new_thread
+from Mailnag.backends.imap import ImapBackend
+from Mailnag.backends.pop3 import Pop3Backend
 from Mailnag.common.dist_cfg import PACKAGE_NAME
 from Mailnag.common.i18n import _
 from Mailnag.common.utils import get_data_file, splitstr
@@ -165,6 +167,13 @@ class AccountDialog:
 				acc.port = p[2]
 			else:
 				raise Exception('Unknown account type')
+		
+		# Create backend
+		# TODO: This is duplicate code with AccountManager.
+		if acc.imap:
+			acc.backend = ImapBackend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl, acc.folders)
+		else:
+			acc.backend = Pop3Backend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl)
 	
 	
 	def _get_selected_folders(self):

--- a/Mailnag/daemon/idlers.py
+++ b/Mailnag/daemon/idlers.py
@@ -62,8 +62,8 @@ class Idler(object):
 	# idle thread
 	def _idle(self):
 		# use_existing = True:
-		# connection has been opened in mailnagdaemon.py already (immediate check)
-		self._conn = self._account.get_connection(use_existing = True)
+		# mailbox has been opened in mailnagdaemon.py already (immediate check)
+		self._account.open(reopen = False)
 
 		while True:
 			# if the event is set here, 
@@ -84,10 +84,10 @@ class Idler(object):
 			# if the event is set due to idle sync
 			if self._needsync:
 				self._event.clear()
-				if not self._account.has_connection():
+				if not self._account.is_open():
 					self._reconnect()
 				
-				if self._account.has_connection():
+				if self._account.is_open():
 					self._sync_callback(self._account)
 
 		self._account.cancel_notifications()
@@ -106,12 +106,11 @@ class Idler(object):
 		logging.info("Idler thread for account '%s' has been disconnected" % self._account.name)
 		
 		self._account.close()
-		self._conn = None
-		
-		while (not self._account.has_connection()) and (not self._event.isSet()):
+
+		while (not self._account.is_open()) and (not self._event.isSet()):
 			logging.info("Trying to reconnect Idler thread for account '%s'." % self._account.name)
 			try:
-				self._conn = self._account.get_connection(use_existing = False)
+				self._account.open(reopen = True)
 				logging.info("Successfully reconnected Idler thread for account '%s'." % self._account.name)
 			except Exception as ex:
 				logging.error("Failed to reconnect Idler thread for account '%s' (%s)." % (self._account.name, ex))

--- a/Mailnag/daemon/idlers.py
+++ b/Mailnag/daemon/idlers.py
@@ -25,7 +25,6 @@
 import threading
 import time
 import logging
-from Mailnag.common.imaplib2 import AUTH
 from Mailnag.common.exceptions import InvalidOperationException
 
 
@@ -41,14 +40,7 @@ class Idler(object):
 		self._sync_callback = sync_callback
 		self._account = account
 		self._idle_timeout = idle_timeout
-		# use_existing = True:
-		# connection has been opened in mailnagdaemon.py already (immediate check)
-		self._conn = account.get_connection(use_existing = True)
 		self._disposed = False
-				
-		# Need to get out of AUTH mode of fresh connections.
-		if self._conn.state == AUTH:
-			self._select(self._conn, account)
 
 
 	def start(self):
@@ -63,34 +55,27 @@ class Idler(object):
 			self._event.set()
 			self._thread.join()
 		
-		try:
-			if self._conn != None:
-				# Exit possible active idle state.
-				# (also calls idle_callback)
-				self._conn.noop()
-		except:
-			pass
-		
 		self._disposed = True
 		logging.info('Idler closed')
 
 		
 	# idle thread
 	def _idle(self):
+		# use_existing = True:
+		# connection has been opened in mailnagdaemon.py already (immediate check)
+		self._conn = self._account.get_connection(use_existing = True)
+
 		while True:
 			# if the event is set here, 
 			# disposed() must have been called
 			# so stop the idle thread.
 			if self._event.isSet():
-				return
+				break
 			
 			self._needsync = False
 			self._conn_closed = False
 
-			# register idle callback that is called whenever an idle event arrives (new mail / mail deleted).
-			# the callback is called after <idle_timeout> minutes at the latest. 
-			# gmail sends keepalive events every 5 minutes.
-			self._conn.idle(callback = self._idle_callback, timeout = 60 * self._idle_timeout)
+			self._account.notify_next_change(callback = self._idle_callback, timeout = 60 * self._idle_timeout)
 			
 			# waits for the event to be set
 			# (in idle callback or in dispose())
@@ -99,17 +84,17 @@ class Idler(object):
 			# if the event is set due to idle sync
 			if self._needsync:
 				self._event.clear()
-				if self._conn_closed:
+				if not self._account.has_connection():
 					self._reconnect()
 				
-				if self._conn != None:
+				if self._account.has_connection():
 					self._sync_callback(self._account)
 
+		self._account.cancel_notifications()
+		
 	
 	# idle callback (runs on a further thread)
 	def _idle_callback(self, args):
-		# check if the connection has been reset by provider
-		self._conn_closed = (args[2] != None) and (args[2][0] is self._conn.abort)
 		# flag that a mail sync is needed
 		self._needsync = True
 		# trigger waiting _idle thread
@@ -120,14 +105,10 @@ class Idler(object):
 		# connection has been reset by provider -> try to reconnect
 		logging.info("Idler thread for account '%s' has been disconnected" % self._account.name)
 		
-		# conn has already been closed, don't try to close it again
-		# self._conn.close() # (calls idle_callback)
-		
-		# shutdown existing callback thread
-		self._conn.logout()
+		self._account.close()
 		self._conn = None
 		
-		while (self._conn == None) and (not self._event.isSet()): 
+		while (not self._account.has_connection()) and (not self._event.isSet()):
 			logging.info("Trying to reconnect Idler thread for account '%s'." % self._account.name)
 			try:
 				self._conn = self._account.get_connection(use_existing = False)
@@ -137,18 +118,8 @@ class Idler(object):
 				logging.info("Trying to reconnect Idler thread for account '%s' in %s minutes" % 
 					(self._account.name, str(self.RECONNECT_RETRY_INTERVAL)))
 				self._wait(60 * self.RECONNECT_RETRY_INTERVAL) # don't hammer the server
-			
-		if self._conn != None:
-			self._select(self._conn, self._account)
 	
 					
-	def _select(self, conn, account):
-		if len(account.folders) == 1:
-			conn.select(account.folders[0])
-		else:
-			conn.select("INBOX")
-	
-			
 	def _wait(self, secs):
 		start_time = time.time()
 		while (((time.time() - start_time) < secs) and (not self._event.isSet())):

--- a/Mailnag/daemon/idlers.py
+++ b/Mailnag/daemon/idlers.py
@@ -4,6 +4,7 @@
 # idlers.py
 #
 # Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
 # Copyright 2011 Leighton Earl <leighton.earl@gmx.com>
 #
 # This program is free software; you can redistribute it and/or modify

--- a/Mailnag/daemon/mailnagdaemon.py
+++ b/Mailnag/daemon/mailnagdaemon.py
@@ -3,6 +3,7 @@
 #
 # mailnagdaemon.py
 #
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
 # Copyright 2014, 2015 Patrick Ulbrich <zulu99@gmx.net>
 #
 # This program is free software; you can redistribute it and/or modify

--- a/Mailnag/daemon/mailnagdaemon.py
+++ b/Mailnag/daemon/mailnagdaemon.py
@@ -128,12 +128,7 @@ class MailnagDaemon:
 		if self._accounts != None:
 			for acc in self._accounts:
 				if acc.has_connection():
-					conn = acc.get_connection(use_existing = True)
-					if acc.imap:
-						conn.close()
-						conn.logout()
-					else:
-						conn.quit()
+					acc.close()
 
 		self._unload_plugins()
 	

--- a/Mailnag/daemon/mailnagdaemon.py
+++ b/Mailnag/daemon/mailnagdaemon.py
@@ -127,7 +127,7 @@ class MailnagDaemon:
 
 		if self._accounts != None:
 			for acc in self._accounts:
-				if acc.has_connection():
+				if acc.is_open():
 					acc.close()
 
 		self._unload_plugins()

--- a/Mailnag/daemon/mails.py
+++ b/Mailnag/daemon/mails.py
@@ -4,6 +4,7 @@
 # mails.py
 #
 # Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
 # Copyright 2011 Leighton Earl <leighton.earl@gmx.com>
 # Copyright 2011 Ralf Hersel <ralf.hersel@gmx.net>
 #

--- a/Mailnag/daemon/mails.py
+++ b/Mailnag/daemon/mails.py
@@ -111,10 +111,6 @@ class MailCollector:
 								sender, id, acc))
 							mail_ids[id] = None
 				
-				# don't close IMAP idle connections
-				if not acc.idle:
-					conn.close()
-					conn.logout()
 			else: # POP
 				# number of mails on the server
 				mail_total = len(conn.list()[1])
@@ -148,8 +144,10 @@ class MailCollector:
 							id, acc))
 						mail_ids[id] = None
 
+			# don't close idle connections
+			if not acc.idle:
 				# disconnect from Email-Server
-				conn.quit()
+				acc.close()
 		
 		# sort mails
 		if sort:

--- a/Mailnag/daemon/mails.py
+++ b/Mailnag/daemon/mails.py
@@ -61,12 +61,11 @@ class MailCollector:
 		mail_ids = {}
 		
 		for acc in self._accounts:
-			# get server connection for this account
-			conn = None
+			# open mailbox for  this account
 			try:
-				conn = acc.get_connection(use_existing = True)
+				acc.open(reopen = False)
 			except Exception as ex:
-				logging.error("Failed to connect to account '%s' (%s)." % (acc.name, ex))
+				logging.error("Failed to open mailbox for account '%s' (%s)." % (acc.name, ex))
 				continue
 
 			for folder, msg in acc.list_messages():

--- a/Mailnag/daemon/mails.py
+++ b/Mailnag/daemon/mails.py
@@ -69,35 +69,20 @@ class MailCollector:
 				logging.error("Failed to connect to account '%s' (%s)." % (acc.name, ex))
 				continue
 
-			if acc.imap: # IMAP
-				for folder, msg in acc.list_messages():
-					sender, subject, datetime, msgid = self._get_header(msg)
-					id = self._get_id(msgid, acc, folder, sender, subject, datetime)
-				
-					# Discard mails with identical IDs (caused 
-					# by mails with a non-unique fallback ID, 
-					# i.e. mails received in the same folder with 
-					# identical sender and subject but *no datetime*, 
-					# see _get_id()).
-					# Also filter duplicates caused by Gmail labels.
-					if id not in mail_ids:
-						mail_list.append(Mail(datetime, subject, \
-							sender, id, acc))
-						mail_ids[id] = None
-				
-			else: # POP
-				for folder, msg in acc.list_messages():
-					sender, subject, datetime, msgid = self._get_header(msg)
-					id = self._get_id(msgid, acc, folder, sender, subject, datetime)
-					
-					# Discard mails with identical IDs (caused 
-					# by mails with a non-unique fallback ID, 
-					# i.e. mails with identical sender and subject 
-					# but *no datetime*, see _get_id()).
-					if id not in mail_ids:
-						mail_list.append(Mail(datetime, subject, sender, \
-							id, acc))
-						mail_ids[id] = None
+			for folder, msg in acc.list_messages():
+				sender, subject, datetime, msgid = self._get_header(msg)
+				id = self._get_id(msgid, acc, folder, sender, subject, datetime)
+			
+				# Discard mails with identical IDs (caused
+				# by mails with a non-unique fallback ID,
+				# i.e. mails received in the same folder with
+				# identical sender and subject but *no datetime*,
+				# see _get_id()).
+				# Also filter duplicates caused by Gmail labels.
+				if id not in mail_ids:
+					mail_list.append(Mail(datetime, subject, \
+						sender, id, acc))
+					mail_ids[id] = None
 
 			# don't close idle connections
 			if not acc.idle:


### PR DESCRIPTION
This is first part of https://github.com/pulb/mailnag/issues/21. I moved IMAP and POP3 code to backend classes. The code logic should be same as before. I hope I didn't break anything. I changed some method names so that backend interface would not be so protocol specific.