### PR TITLE
Configuration file changes and first version of mbox mailbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 locale
 Mailnag/plugins/goaplugin.py
 Mailnag/plugins/messagingmenuplugin.py
+/.cache
+

--- a/Mailnag/backends/__init__.py
+++ b/Mailnag/backends/__init__.py
@@ -22,3 +22,15 @@
 
 """Backends to implement mail box specific functionality, like IMAP and POP3."""
 
+from Mailnag.backends.imap import IMAPBackend
+from Mailnag.backends.pop3 import POP3Backend
+
+_backends = {
+	'imap' : IMAPBackend,
+	'pop3' : POP3Backend,
+}
+
+def create_backend(mailbox_type, name, **kw):
+	"""Create mailbox backend of specified type, name and other parameters."""
+	return _backends[mailbox_type](name, **kw)
+

--- a/Mailnag/backends/__init__.py
+++ b/Mailnag/backends/__init__.py
@@ -22,12 +22,12 @@
 
 """Backends to implement mail box specific functionality, like IMAP and POP3."""
 
-from Mailnag.backends.imap import IMAPBackend
-from Mailnag.backends.pop3 import POP3Backend
+from Mailnag.backends.imap import IMAPMailboxBackend
+from Mailnag.backends.pop3 import POP3MailboxBackend
 
 _backends = {
-	'imap' : IMAPBackend,
-	'pop3' : POP3Backend,
+	'imap' : IMAPMailboxBackend,
+	'pop3' : POP3MailboxBackend,
 }
 
 def create_backend(mailbox_type, name, **kw):

--- a/Mailnag/backends/__init__.py
+++ b/Mailnag/backends/__init__.py
@@ -28,6 +28,7 @@ import re
 
 from Mailnag.backends.imap import IMAPMailboxBackend
 from Mailnag.backends.pop3 import POP3MailboxBackend
+from Mailnag.backends.local import MBoxBackend
 from Mailnag.common.utils import splitstr
 
 
@@ -76,12 +77,15 @@ _backends = {
 				Param('imap', 'imap', _str_to_bool, _bool_to_str, False),
 				Param('idle', 'idle', _str_to_bool, _bool_to_str, False),
 			 ]),
+	'mbox' : Backend(MBoxBackend, [
+				Param('path', 'path', str, str, ''),
+			 ]),
 }
 
 
-def create_backend(mailbox_type, name, **kw):
-	"""Create mailbox backend of specified type, name and other parameters."""
-	return _backends[mailbox_type].backend_class(name, **kw)
+def create_backend(mailbox_type, **kw):
+	"""Create mailbox backend of specified type and parameters."""
+	return _backends[mailbox_type].backend_class(**kw)
 
 
 def get_mailbox_parameter_specs(mailbox_type):

--- a/Mailnag/backends/__init__.py
+++ b/Mailnag/backends/__init__.py
@@ -22,15 +22,66 @@
 
 """Backends to implement mail box specific functionality, like IMAP and POP3."""
 
+from collections import namedtuple
+import json
+import re
+
 from Mailnag.backends.imap import IMAPMailboxBackend
 from Mailnag.backends.pop3 import POP3MailboxBackend
+from Mailnag.common.utils import splitstr
+
+
+def _str_to_folders(folders_str):
+	if re.match(r'^\[.*\]$', folders_str):
+		folders	= json.loads(folders_str)
+	else:
+		folders	= splitstr(folders_str, ',')
+	return folders
+
+
+def _str_to_bool(string):
+	return bool(int(string))
+
+
+Param = namedtuple('Param', ['param_name', 'option_name', 'from_str', 'default_value'])
+Backend = namedtuple('Backend', ['backend_class', 'params'])
 
 _backends = {
-	'imap' : IMAPMailboxBackend,
-	'pop3' : POP3MailboxBackend,
+	'imap' : Backend(IMAPMailboxBackend, [
+				Param('user', 'user', str, ''),
+				Param('password', 'password', str, ''),
+				Param('server', 'server', str, ''),
+				Param('port', 'port', str, ''),
+				Param('ssl', 'ssl', _str_to_bool, True),
+				Param('imap', 'imap', _str_to_bool, True),
+				Param('idle', 'idle', _str_to_bool, True),
+				Param('folders', 'folder', _str_to_folders, []),
+			 ]),
+	'pop3' : Backend(POP3MailboxBackend, [
+				Param('user', 'user', str, ''),
+				Param('password', 'password', str, ''),
+				Param('server', 'server', str, ''),
+				Param('port', 'port', str, ''),
+				Param('ssl', 'ssl', _str_to_bool, True),
+				Param('imap', 'imap', _str_to_bool, False),
+				Param('idle', 'idle', _str_to_bool, False),
+			 ]),
 }
+
 
 def create_backend(mailbox_type, name, **kw):
 	"""Create mailbox backend of specified type, name and other parameters."""
-	return _backends[mailbox_type](name, **kw)
+	return _backends[mailbox_type].backend_class(name, **kw)
+
+
+def get_mailbox_parameter_specs(mailbox_type):
+	"""Returns mailbox backend specific parameter specification.
+	The specification is a list objects which have atributes:
+	* param_name - the name of argument in which parameter value is given to
+				   backend constructor
+	* option_name - the name used in configuration
+	* from_str - the function to convert string to parameter specific type
+	* default_value - the value used when the option is not found
+	"""
+	return _backends[mailbox_type].params
 

--- a/Mailnag/backends/__init__.py
+++ b/Mailnag/backends/__init__.py
@@ -39,32 +39,42 @@ def _str_to_folders(folders_str):
 	return folders
 
 
+def _folders_to_str(folders):
+	return json.dumps(folders)
+
+
 def _str_to_bool(string):
 	return bool(int(string))
 
 
-Param = namedtuple('Param', ['param_name', 'option_name', 'from_str', 'default_value'])
+def _bool_to_str(b):
+	return str(int(b))
+
+
+Param = namedtuple('Param',
+    ['param_name', 'option_name', 'from_str', 'to_str', 'default_value']
+)
 Backend = namedtuple('Backend', ['backend_class', 'params'])
 
 _backends = {
 	'imap' : Backend(IMAPMailboxBackend, [
-				Param('user', 'user', str, ''),
-				Param('password', 'password', str, ''),
-				Param('server', 'server', str, ''),
-				Param('port', 'port', str, ''),
-				Param('ssl', 'ssl', _str_to_bool, True),
-				Param('imap', 'imap', _str_to_bool, True),
-				Param('idle', 'idle', _str_to_bool, True),
-				Param('folders', 'folder', _str_to_folders, []),
+				Param('user', 'user', str, str, ''),
+				Param('password', 'password', str, str, ''),
+				Param('server', 'server', str, str, ''),
+				Param('port', 'port', str, str, ''),
+				Param('ssl', 'ssl', _str_to_bool, _bool_to_str, True),
+				Param('imap', 'imap', _str_to_bool, _bool_to_str, True),
+				Param('idle', 'idle', _str_to_bool, _bool_to_str, True),
+				Param('folders', 'folder', _str_to_folders, _folders_to_str, []),
 			 ]),
 	'pop3' : Backend(POP3MailboxBackend, [
-				Param('user', 'user', str, ''),
-				Param('password', 'password', str, ''),
-				Param('server', 'server', str, ''),
-				Param('port', 'port', str, ''),
-				Param('ssl', 'ssl', _str_to_bool, True),
-				Param('imap', 'imap', _str_to_bool, False),
-				Param('idle', 'idle', _str_to_bool, False),
+				Param('user', 'user', str, str, ''),
+				Param('password', 'password', str, str, ''),
+				Param('server', 'server', str, str, ''),
+				Param('port', 'port', str, str, ''),
+				Param('ssl', 'ssl', _str_to_bool, _bool_to_str, True),
+				Param('imap', 'imap', _str_to_bool, _bool_to_str, False),
+				Param('idle', 'idle', _str_to_bool, _bool_to_str, False),
 			 ]),
 }
 

--- a/Mailnag/backends/base.py
+++ b/Mailnag/backends/base.py
@@ -63,7 +63,7 @@ class MailboxBackend(object):
 	@abstractmethod
 	def request_folders(self):
 		"""Returns list of folder names available in the mailbox.
-		Returns an empty list if mailbox does not support folders.
+		Raises an exceptions if mailbox does not support folders.
 		"""
 		raise NotImplementedError
 

--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -39,7 +39,7 @@ class IMAPMailboxBackend(MailboxBackend):
 	"""Implementation of IMAP mail boxes."""
 
 	def __init__(self, name = '', user = '', password = '', oauth2string = '',
-				 server = '', port = '', ssl = True, folders = []):
+				 server = '', port = '', ssl = True, folders = [], **kw):
 		self.name = name
 		self.user = user
 		self.password = password

--- a/Mailnag/backends/local.py
+++ b/Mailnag/backends/local.py
@@ -71,11 +71,8 @@ class MBoxBackend(MailboxBackend):
 
 
 	def request_folders(self):
-		"""List folders in mailbox.
-		This returns always empty list, because mbox does not support folders.
-		"""
-		lst = []
-		return lst
+		"""mbox does not suppoert folders."""
+		raise NotImplementedError("mbox does not support folders")
 
 
 	def notify_next_change(self, callback=None, timeout=None):

--- a/Mailnag/backends/local.py
+++ b/Mailnag/backends/local.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# local.py
+#
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+"""Implementation of local mailboxes, like mbox and maildir."""
+
+import email
+import mailbox
+import logging
+import os.path
+
+class MBoxBackend:
+	"""Implementation of mbox mail boxes."""
+	
+	def __init__(self, name = '', path=None):
+		"""Initialize mbox mailbox backens with a name and path."""
+		self.name = name
+		self.path = path
+		self.opened = False
+
+
+	def open(self, reopen=False):
+		"""'Open' mbox. (Actually just checks that mailbox file exists.)"""
+		if not os.path.isfile(self.path):
+			raise IOError('Mailbox {} does not exist.'.format(self.path))
+		self.opened = True
+
+
+	def close(self):
+		"""Close mbox."""
+		self.opened = False
+
+
+	def is_open(self):
+		"""Return True if mailbox is opened."""
+		return self.opened
+
+
+	def list_messages(self):
+		"""List unread messages from the mailbox.
+		Yields pairs (folder, message) where folder is always ''.
+		"""
+		mbox = mailbox.mbox(self.path, create=False)
+		folder = ''
+		try:
+			for msg in mbox:
+				if 'R' not in msg.get_flags():
+					yield folder, msg
+		finally:
+			mbox.close()
+
+
+	def request_folders(self):
+		"""List folders in mailbox.
+		This returns always empty list, because mbox does not support folders.
+		"""
+		lst = []
+		return lst
+
+
+	def notify_next_change(self, callback=None, timeout=None):
+		raise NotImplementedError("mbox does not support notifications")
+
+
+	def cancel_notifications(self):
+		raise NotImplementedError("mbox does not support notifications")
+

--- a/Mailnag/backends/local.py
+++ b/Mailnag/backends/local.py
@@ -27,10 +27,12 @@ import mailbox
 import logging
 import os.path
 
-class MBoxBackend:
+from Mailnag.backends.base import MailboxBackend
+
+class MBoxBackend(MailboxBackend):
 	"""Implementation of mbox mail boxes."""
 	
-	def __init__(self, name = '', path=None):
+	def __init__(self, name = '', path=None, **kw):
 		"""Initialize mbox mailbox backens with a name and path."""
 		self.name = name
 		self.path = path

--- a/Mailnag/backends/pop3.py
+++ b/Mailnag/backends/pop3.py
@@ -37,7 +37,7 @@ class POP3MailboxBackend(MailboxBackend):
 	"""Implementation of POP3 mail boxes."""
 	
 	def __init__(self, name = '', user = '', password = '', oauth2string = '',
-				 server = '', port = '', ssl = True):
+				 server = '', port = '', ssl = True, **kw):
 		self.name = name
 		self.user = user
 		self.password = password

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -48,7 +48,7 @@ CREDENTIAL_KEY = 'Mailnag password for %s://%s@%s'
 #
 class Account:
 	def __init__(self, enabled = False, name = '', user = '', \
-		password = '', oauth2string = '', server = '', port = '', ssl = True, imap = True, idle = True, folders = [], mailbox_type = None, **kw):
+		password = '', oauth2string = '', server = '', port = '', ssl = True, imap = True, idle = False, folders = [], mailbox_type = None, **kw):
 		
 		self.enabled = enabled # bool
 		if mailbox_type:

--- a/Mailnag/configuration/accountdialog.py
+++ b/Mailnag/configuration/accountdialog.py
@@ -28,7 +28,6 @@ gi.require_version('GLib', '2.0')
 
 from gi.repository import GObject, GLib, Gtk
 from thread import start_new_thread
-from Mailnag.backends import create_backend
 from Mailnag.common.dist_cfg import PACKAGE_NAME
 from Mailnag.common.i18n import _
 from Mailnag.common.utils import get_data_file, splitstr
@@ -167,10 +166,6 @@ class AccountDialog:
 				acc.port = p[2]
 			else:
 				raise Exception('Unknown account type')
-		
-		# Create backend
-		# TODO: This is duplicate code with AccountManager.
-		acc.backend = create_backend(acc.mailbox_type, name=acc.name, user=acc.user, password=acc.password, server=acc.server, port=acc.port, ssl=acc.ssl, folders=acc.folders)
 	
 	
 	def _get_selected_folders(self):

--- a/Mailnag/configuration/accountdialog.py
+++ b/Mailnag/configuration/accountdialog.py
@@ -28,8 +28,7 @@ gi.require_version('GLib', '2.0')
 
 from gi.repository import GObject, GLib, Gtk
 from thread import start_new_thread
-from Mailnag.backends.imap import IMAPMailboxBackend
-from Mailnag.backends.pop3 import POP3MailboxBackend
+from Mailnag.backends import create_backend
 from Mailnag.common.dist_cfg import PACKAGE_NAME
 from Mailnag.common.i18n import _
 from Mailnag.common.utils import get_data_file, splitstr
@@ -171,10 +170,7 @@ class AccountDialog:
 		
 		# Create backend
 		# TODO: This is duplicate code with AccountManager.
-		if acc.imap:
-			acc.backend = IMAPMailboxBackend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl, acc.folders)
-		else:
-			acc.backend = POP3MailboxBackend(acc.name, acc.user, acc.password, '', acc.server, acc.port, acc.ssl)
+		acc.backend = create_backend(acc.mailbox_type, name=acc.name, user=acc.user, password=acc.password, server=acc.server, port=acc.port, ssl=acc.ssl, folders=acc.folders)
 	
 	
 	def _get_selected_folders(self):

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# test_account.py
+#
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+"""Test cases for Account."""
+
+from Mailnag.common.accounts import Account
+
+
+def test_account_should_keep_configuration():
+	account = Account(enabled=True,
+					  name='my name',
+					  user='who',
+					  password='secret',
+					  oauth2string='who knows',
+					  server='example.org',
+					  port='1234',
+					  ssl=True,
+					  imap=True,
+					  idle=True,
+					  folders=['a', 'b'],
+					  mailbox_type='mybox')
+	config = account.get_config()
+	expected_config = {
+		'enabled': True,
+		'name': 'my name',
+		'user': 'who',
+		'password': 'secret',
+		'oauth2string': 'who knows',
+		'server': 'example.org', 
+		'port': '1234',
+		'ssl': True,
+		'imap': True, 
+		'idle': True, 
+		'folders': ['a', 'b'], 
+		'mailbox_type': 'mybox',
+	}
+	assert expected_config == config
+
+
+def test_account_config_should_always_contain_certain_values():
+	account = Account()
+	config = account.get_config()
+	assert 'enabled' in config
+	assert 'name' in config
+	assert 'mailbox_type' in config
+
+
+def test_account_should_configurable_with_any_parameters():
+	account = Account(weird='odd', odd='weird')
+	config = account.get_config()
+	assert config['weird'] == 'odd'
+	assert config['odd'] == 'weird'
+

--- a/tests/test_accountmanager.py
+++ b/tests/test_accountmanager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# test_backends.py
+# test_accountmanager.py
 #
 # Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
 #
@@ -167,4 +167,33 @@ def test_pop3_config_defaults(config):
 		'idle': False,
 	}
 	assert expected_options == options
+
+
+def test_imap_config_values_should_be_stored():
+	am = AccountManager()
+	option_spec = get_mailbox_parameter_specs('imap')
+	options = {
+		'user': 'you',
+		'password': '',
+		'server': 'imap.example.org',
+		'port': '',
+		'ssl': True,
+		'imap': True,
+		'idle': True,
+		'folders': ['a', 'b'],
+	}
+	config = RawConfigParser()
+	config.add_section('account1')
+	am._set_cfg_options(config, 'account1', options, option_spec)
+	expected_config_items = [
+		('user', 'you'),
+		('password', ''),
+		('server', 'imap.example.org'),
+		('port', ''),
+		('ssl', '1'),
+		('imap', '1'),
+		('idle', '1'),
+		('folder', '["a", "b"]'),
+	]
+	assert set(expected_config_items) == set(config.items('account1'))
 

--- a/tests/test_accountmanager.py
+++ b/tests/test_accountmanager.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+#
+# test_backends.py
+#
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+"""Test cases for account manager."""
+
+from ConfigParser import RawConfigParser
+from io import StringIO
+import pytest
+
+from Mailnag.backends import get_mailbox_parameter_specs
+from Mailnag.common.accounts import AccountManager
+
+
+sample_config_file = u"""
+[account1]
+enabled = 1
+name = IMAP mailbox config
+user = you
+password =
+server = imap.example.org
+port =
+ssl = 1
+imap = 1
+idle = 1
+folder = []
+
+[account2]
+enabled = 1
+name = POP3 mailbox config
+user = me
+password =
+server = pop.example.org
+port =
+ssl = 1
+imap = 0
+idle = 0
+folder = []
+
+[account3]
+enabled = 1
+name = Empty account config for testing default values
+
+[account4]
+enabled = 1
+name = Imap config with empty folder option
+folder =
+
+[account5]
+enabled = 1
+name = Imap config with old style folder option
+folder = folderA, folderB, folderC
+
+[account6]
+enabled = 1
+name = Imap config with json folder option
+folder = folderA, folderB, folderC
+"""
+
+@pytest.fixture
+def config():
+	cp = RawConfigParser()
+	cp.readfp(StringIO(sample_config_file), filename='sample_config_file')
+	return cp
+
+
+def test_imap_config_options(config):
+	am = AccountManager()
+	option_spec = get_mailbox_parameter_specs('imap')
+	options = am._get_cfg_options(config, 'account1', option_spec)
+	expected_options = {
+		'user': 'you',
+		'password': '',
+		'server': 'imap.example.org',
+		'port': '',
+		'ssl': True,
+		'imap': True,
+		'idle': True,
+		'folders': [],
+	}
+	assert expected_options == options
+
+
+def test_imap_config_defaults(config):
+	am = AccountManager()
+	option_spec = get_mailbox_parameter_specs('imap')
+	options = am._get_cfg_options(config, 'account3', option_spec)
+	expected_options = {
+		'user': '',
+		'password': '',
+		'server': '',
+		'port': '',
+		'ssl': True,
+		'imap': True,
+		'idle': True,
+		'folders': [],
+	}
+	assert expected_options == options
+
+
+def test_imap_empty_folder_option(config):
+	am = AccountManager()
+	option_spec = get_mailbox_parameter_specs('imap')
+	options = am._get_cfg_options(config, 'account4', option_spec)
+	assert options['folders'] == []
+
+
+def test_imap_old_folder_option(config):
+	am = AccountManager()
+	option_spec = get_mailbox_parameter_specs('imap')
+	options = am._get_cfg_options(config, 'account5', option_spec)
+	assert options['folders'] == ['folderA', 'folderB', 'folderC']
+
+
+def test_imap_new_folder_option(config):
+	am = AccountManager()
+	option_spec = get_mailbox_parameter_specs('imap')
+	options = am._get_cfg_options(config, 'account6', option_spec)
+	assert options['folders'] == ['folderA', 'folderB', 'folderC']
+
+
+def test_pop3_config_options(config):
+	am = AccountManager()
+	option_spec = get_mailbox_parameter_specs('pop3')
+	options = am._get_cfg_options(config, 'account2', option_spec)
+	expected_options = {
+		'user': 'me',
+		'password': '',
+		'server': 'pop.example.org',
+		'port': '',
+		'ssl': True,
+		'imap': False,
+		'idle': False,
+	}
+	assert expected_options == options
+
+
+def test_pop3_config_defaults(config):
+	am = AccountManager()
+	option_spec = get_mailbox_parameter_specs('pop3')
+	options = am._get_cfg_options(config, 'account3', option_spec)
+	expected_options = {
+		'user': '',
+		'password': '',
+		'server': '',
+		'port': '',
+		'ssl': True,
+		'imap': False,
+		'idle': False,
+	}
+	assert expected_options == options
+

--- a/tests/test_backend_local.py
+++ b/tests/test_backend_local.py
@@ -25,23 +25,23 @@
 import mailbox
 import pytest
 
-from Mailnag.backends.local import MBoxBackend
+from Mailnag.backends import create_backend
 
 
 def test_create_mbox_backend():
-	be = MBoxBackend()
+	be = create_backend('mbox')
 	assert be is not None
 
 
 def test_initially_mailbox_should_be_closed():
-	be = MBoxBackend()
+	be = create_backend('mbox')
 	assert not be.is_open()
 
 
 def test_when_opened_mailbox_should_be_open(tmpdir):
 	tmpdir.join('sample').write('')
 	path = str(tmpdir.join('sample'))
-	be = MBoxBackend(path=path)
+	be = create_backend('mbox', path=path)
 	be.open()
 	assert be.is_open()
 
@@ -49,7 +49,7 @@ def test_when_opened_mailbox_should_be_open(tmpdir):
 def test_closed_mailbox_should_be_closed(tmpdir):
 	tmpdir.join('sample').write('')
 	path = str(tmpdir.join('sample'))
-	be = MBoxBackend(path=path)
+	be = create_backend('mbox', path=path)
 	be.open()
 	be.close()
 	assert not be.is_open()
@@ -59,7 +59,7 @@ def test_mbox_lists_no_messages_from_empty_mailbox(tmpdir):
 	path = str(tmpdir.join('sample'))
 	sample_mbox = mailbox.mbox(path, create=True)
 
-	be = MBoxBackend(name='sample', path=path)
+	be = create_backend('mbox', name='sample', path=path)
 	be.open()
 	try:
 		msgs = list(be.list_messages())
@@ -76,7 +76,7 @@ def test_mbox_lists_two_messages_from_mailbox(tmpdir):
 	add_mbox_message(sample_mbox, 'blaa-blaa-3', 'RO')
 	sample_mbox.close()
 
-	be = MBoxBackend(name='sample', path=path)
+	be = create_backend('mbox', name='sample', path=path)
 	be.open()
 	try:
 		msgs = list(be.list_messages())
@@ -92,7 +92,7 @@ def test_mbox_lists_two_messages_from_mailbox(tmpdir):
 def test_mbox_should_not_have_folders(tmpdir):
 	tmpdir.join('sample').write('')
 	path = str(tmpdir.join('sample'))
-	be = MBoxBackend(path=path)
+	be = create_backend('mbox', path=path)
 	be.open()
 	assert be.request_folders() == []
 
@@ -100,7 +100,7 @@ def test_mbox_should_not_have_folders(tmpdir):
 def test_mbox_does_not_support_notifications(tmpdir): # for now
 	tmpdir.join('sample').write('')
 	path = str(tmpdir.join('sample'))
-	be = MBoxBackend(path=path)
+	be = create_backend('mbox', path=path)
 	be.open()
 	with pytest.raises(NotImplementedError):
 		be.notify_next_change()
@@ -111,7 +111,7 @@ def test_mbox_does_not_support_notifications(tmpdir): # for now
 def test_mbox_open_should_fail_if_mailbox_does_not_exist(tmpdir):
 	path = str(tmpdir.join('not-exist'))
 
-	be = MBoxBackend(path=path)
+	be = create_backend('mbox', path=path)
 	with pytest.raises(IOError):
 		be.open()
 

--- a/tests/test_backend_local.py
+++ b/tests/test_backend_local.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+#
+# test_backend_local.py
+#
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+"""Tests for local backends."""
+
+import mailbox
+import pytest
+
+from Mailnag.backends.local import MBoxBackend
+
+
+def test_create_mbox_backend():
+	be = MBoxBackend()
+	assert be is not None
+
+
+def test_initially_mailbox_should_be_closed():
+	be = MBoxBackend()
+	assert not be.is_open()
+
+
+def test_when_opened_mailbox_should_be_open(tmpdir):
+	tmpdir.join('sample').write('')
+	path = str(tmpdir.join('sample'))
+	be = MBoxBackend(path=path)
+	be.open()
+	assert be.is_open()
+
+
+def test_closed_mailbox_should_be_closed(tmpdir):
+	tmpdir.join('sample').write('')
+	path = str(tmpdir.join('sample'))
+	be = MBoxBackend(path=path)
+	be.open()
+	be.close()
+	assert not be.is_open()
+
+
+def test_mbox_lists_no_messages_from_empty_mailbox(tmpdir):
+	path = str(tmpdir.join('sample'))
+	sample_mbox = mailbox.mbox(path, create=True)
+
+	be = MBoxBackend(name='sample', path=path)
+	be.open()
+	try:
+		msgs = list(be.list_messages())
+		assert len(msgs) == 0
+	finally:
+		be.close()
+
+
+def test_mbox_lists_two_messages_from_mailbox(tmpdir):
+	path = str(tmpdir.join('sample'))
+	sample_mbox = mailbox.mbox(path, create=True)
+	add_mbox_message(sample_mbox, 'blaa-blaa-1', '')
+	add_mbox_message(sample_mbox, 'blaa-blaa-2', 'O')
+	add_mbox_message(sample_mbox, 'blaa-blaa-3', 'RO')
+	sample_mbox.close()
+
+	be = MBoxBackend(name='sample', path=path)
+	be.open()
+	try:
+		msgs = list(be.list_messages())
+		folders = [folder for folder, msg in msgs]
+		msg_ids = set(msg.get('message-id') for folder, msg in msgs)
+	finally:
+		be.close()
+	assert len(msgs) == 2
+	assert all(folder == '' for folder in folders)
+	assert msg_ids == set(['blaa-blaa-1', 'blaa-blaa-2'])
+
+
+def test_mbox_should_not_have_folders(tmpdir):
+	tmpdir.join('sample').write('')
+	path = str(tmpdir.join('sample'))
+	be = MBoxBackend(path=path)
+	be.open()
+	assert be.request_folders() == []
+
+
+def test_mbox_does_not_support_notifications(tmpdir): # for now
+	tmpdir.join('sample').write('')
+	path = str(tmpdir.join('sample'))
+	be = MBoxBackend(path=path)
+	be.open()
+	with pytest.raises(NotImplementedError):
+		be.notify_next_change()
+	with pytest.raises(NotImplementedError):
+		be.cancel_notifications()
+
+
+def test_mbox_open_should_fail_if_mailbox_does_not_exist(tmpdir):
+	path = str(tmpdir.join('not-exist'))
+
+	be = MBoxBackend(path=path)
+	with pytest.raises(IOError):
+		be.open()
+
+
+# Helper fuctions
+
+def add_mbox_message(mbox, msg_id, flags):
+	m = mailbox.mboxMessage()
+	m.set_payload('Hello world!', 'ascii')
+	m.add_header('from', 'me@example.org')
+	m.add_header('to', 'you@example.org')
+	m.add_header('subject', 'Hi!')
+	m.add_header('message-id', msg_id)
+	m.set_flags(flags)
+	mbox.lock()
+	try:
+		mbox.add(m)
+	finally:
+		mbox.unlock()
+

--- a/tests/test_backend_local.py
+++ b/tests/test_backend_local.py
@@ -94,7 +94,8 @@ def test_mbox_should_not_have_folders(tmpdir):
 	path = str(tmpdir.join('sample'))
 	be = create_backend('mbox', path=path)
 	be.open()
-	assert be.request_folders() == []
+	with pytest.raises(NotImplementedError):
+		be.request_folders()
 
 
 def test_mbox_does_not_support_notifications(tmpdir): # for now

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# test_backends.py
+#
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+"""Test cases for backends."""
+
+from Mailnag.backends import create_backend
+
+def test_create_imap_backend():
+	be = create_backend('imap', name='testing', user='nobody', password='', server='imap.example.org', port='', ssl=True, folders=['a', 'b'])
+	assert be is not None
+	assert not be.is_open()
+	assert be.server == 'imap.example.org'
+
+def test_create_imap_backend_with_defaults():
+	be = create_backend('imap', name='testing')
+	assert be is not None
+	assert not be.is_open()
+	assert be.server == ''
+
+def test_create_imap_backend_should_ignore_unknown_setting():
+	be = create_backend('imap', name='testing', odd='weird', weird='odd')
+	assert be is not None
+
+
+def test_create_pop3_backend():
+	be = create_backend('pop3', name='testing', user='nobody', password='', server='pop.example.org', port='', ssl=True)
+	assert be is not None
+	assert not be.is_open()
+	assert be.server == 'pop.example.org'
+
+def test_create_pop3_backend_with_defaults():
+	be = create_backend('pop3', name='testing')
+	assert be is not None
+	assert not be.is_open()
+	assert be.server == ''
+
+def test_create_pop3_backend_should_ignore_unknown_setting():
+	be = create_backend('pop3', name='testing', odd='weird', weird='odd')
+	assert be is not None
+

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -22,7 +22,7 @@
 
 """Test cases for backends."""
 
-from Mailnag.backends import create_backend
+from Mailnag.backends import create_backend, get_mailbox_parameter_specs
 
 def test_create_imap_backend():
 	be = create_backend('imap', name='testing', user='nobody', password='', server='imap.example.org', port='', ssl=True, folders=['a', 'b'])
@@ -56,4 +56,17 @@ def test_create_pop3_backend_with_defaults():
 def test_create_pop3_backend_should_ignore_unknown_setting():
 	be = create_backend('pop3', name='testing', odd='weird', weird='odd')
 	assert be is not None
+
+
+def test_imap_backend_parameter_names():
+	specs = get_mailbox_parameter_specs('imap')
+	names = [spec.param_name for spec in specs]
+	assert set(['user', 'password', 'server', 'port',
+				'ssl', 'imap', 'idle', 'folders']) == set(names)
+
+def test_pop3_backend_parameter_names():
+	specs = get_mailbox_parameter_specs('pop3')
+	names = [spec.param_name for spec in specs]
+	assert set(['user', 'password', 'server', 'port',
+				'ssl', 'imap', 'idle']) == set(names)
 


### PR DESCRIPTION
This is second part of local mailbox implementations https://github.com/pulb/mailnag/issues/21.

I have made following changes:
- type field added to configuration. It can currently be imap, pop3 or mbox. If type field is not available, imap field is used, so old configurations are supported.
- Mailbox backend creation is moved to Account class. It creates backend when needed.
- Mailbox backend specific configurations are defined in Mailnag.backends module, and configuration options can be different for different backends.
- AccountManager gets and puts backend specific options to configuration.
- mbox implementation added.
- Some unit tests added (just to make my life easier... :-))

Mbox can now be configured by editing config file. For example:
```
[account5]
enabled = 1
type = mbox
name = My mbox local mailbox
path = /path/to/my/mbox

```
Configuration dialog is not implemented for mbox yet. Currently it shows mbox as a POP3 mailbox.

Currently mbox supports only polling.

Unit tests can be run using pytest:
`python -m pytest
`
