### PR TITLE
Mbox and maildir review fixes and maildir folder handling change

### DIFF
--- a/Mailnag/backends/local.py
+++ b/Mailnag/backends/local.py
@@ -34,33 +34,33 @@ class MBoxBackend(MailboxBackend):
 	
 	def __init__(self, name = '', path=None, **kw):
 		"""Initialize mbox mailbox backend with a name and path."""
-		self.name = name
-		self.path = path
-		self.opened = False
+		self._name = name
+		self._path = path
+		self._opened = False
 
 
-	def open(self, reopen=False):
+	def open(self):
 		"""'Open' mbox. (Actually just checks that mailbox file exists.)"""
-		if not os.path.isfile(self.path):
-			raise IOError('Mailbox {} does not exist.'.format(self.path))
-		self.opened = True
+		if not os.path.isfile(self._path):
+			raise IOError('Mailbox {} does not exist.'.format(self._path))
+		self._opened = True
 
 
 	def close(self):
 		"""Close mbox."""
-		self.opened = False
+		self._opened = False
 
 
 	def is_open(self):
 		"""Return True if mailbox is opened."""
-		return self.opened
+		return self._opened
 
 
 	def list_messages(self):
 		"""List unread messages from the mailbox.
 		Yields pairs (folder, message) where folder is always ''.
 		"""
-		mbox = mailbox.mbox(self.path, create=False)
+		mbox = mailbox.mbox(self._path, create=False)
 		folder = ''
 		try:
 			for msg in mbox:
@@ -88,35 +88,35 @@ class MaildirBackend(MailboxBackend):
 
 	def __init__(self, name = '', path=None, folders=[], **kw):
 		"""Initialize maildir mailbox backend with a name, path and folders."""
-		self.name = name
-		self.path = path
-		self.folders = folders
-		self.opened = False
+		self._name = name
+		self._path = path
+		self._folders = folders
+		self._opened = False
 
 
-	def open(self, reopen=False):
+	def open(self):
 		"""'Open' mailbox. (Actually just checks that maildir directory exists.)"""
-		if not os.path.isdir(self.path):
-			raise IOError('Mailbox {} does not exist.'.format(self.path))
-		self.opened = True
+		if not os.path.isdir(self._path):
+			raise IOError('Mailbox {} does not exist.'.format(self._path))
+		self._opened = True
 
 
 	def close(self):
 		"""Close mailbox."""
-		self.opened = False
+		self._opened = False
 
 
 	def is_open(self):
 		"""Return True if mailbox is opened."""
-		return self.opened
+		return self._opened
 
 
 	def list_messages(self):
 		"""List unread messages from the mailbox.
 		Yields pairs (folder, message).
 		"""
-		folders = self.folders if len(self.folders) != 0 else ['']
-		root_maildir = mailbox.Maildir(self.path, factory=None, create=False)
+		folders = self._folders if len(self._folders) != 0 else ['']
+		root_maildir = mailbox.Maildir(self._path, factory=None, create=False)
 		try:
 			for folder in folders:
 				if isinstance(folder, unicode):
@@ -135,22 +135,25 @@ class MaildirBackend(MailboxBackend):
 		"""Lists folder from maildir recursively."""
 
 		def list_folders(maildir, parent):
-			for folder in  maildir.list_folders():
+			for folder in maildir.list_folders():
 				this_folder = parent + folder
 				yield this_folder
 				for subfolder in list_folders(maildir.get_folder(folder), this_folder + '/'):
 					yield subfolder
 
-		maildir = mailbox.Maildir(self.path, factory=None, create=False)
-		return [''] + list(list_folders(maildir, ''))
+		maildir = mailbox.Maildir(self._path, factory=None, create=False)
+		try:
+			return [''] + list(list_folders(maildir, ''))
+		finally:
+			maildir.close()
 
 
 	def notify_next_change(self, callback=None, timeout=None):
-		raise NotImplementedError("mbox does not support notifications")
+		raise NotImplementedError("maildir does not support notifications")
 
 
 	def cancel_notifications(self):
-		raise NotImplementedError("mbox does not support notifications")
+		raise NotImplementedError("maildir does not support notifications")
 
 
 	def _get_folder(self, maildir, folder):

--- a/Mailnag/backends/local.py
+++ b/Mailnag/backends/local.py
@@ -132,18 +132,10 @@ class MaildirBackend(MailboxBackend):
 
 
 	def request_folders(self):
-		"""Lists folder from maildir recursively."""
-
-		def list_folders(maildir, parent):
-			for folder in maildir.list_folders():
-				this_folder = parent + folder
-				yield this_folder
-				for subfolder in list_folders(maildir.get_folder(folder), this_folder + '/'):
-					yield subfolder
-
+		"""Lists folders from maildir."""
 		maildir = mailbox.Maildir(self._path, factory=None, create=False)
 		try:
-			return [''] + list(list_folders(maildir, ''))
+			return [''] + maildir.list_folders()
 		finally:
 			maildir.close()
 
@@ -158,9 +150,8 @@ class MaildirBackend(MailboxBackend):
 
 	def _get_folder(self, maildir, folder):
 		"""Returns folder instance of the given maildir."""
-		f = maildir
-		for subfolder in folder.split('/'):
-			if subfolder != '':
-				f = f.get_folder(subfolder)
-		return f
+		if folder == '':
+			return maildir
+		else:
+			return maildir.get_folder(folder)
 

--- a/tests/test_backend_local.py
+++ b/tests/test_backend_local.py
@@ -181,13 +181,13 @@ class TestMaildir:
 	def test_lists_unread_messages_from_selected_folders(self, sample_path, sample_maildir):
 		f = sample_maildir.add_folder('folder1')
 		sample_maildir.add_folder('folder2')
-		s = f.add_folder('subfolder')
+		s = sample_maildir.add_folder('folder1.subfolder')
 		self._add_message(sample_maildir, 'blaa-blaa-1', None, 'new')
 		self._add_message(f, 'blaa-blaa-2', None, 'cur')
 		self._add_message(s, 'blaa-blaa-3', None, 'cur')
 		sample_maildir.close()
 
-		be = create_backend('maildir', name='sample', path=sample_path, folders=['', 'folder1/subfolder'])
+		be = create_backend('maildir', name='sample', path=sample_path, folders=['', 'folder1.subfolder'])
 		be.open()
 		try:
 			msgs = list(be.list_messages())
@@ -196,7 +196,7 @@ class TestMaildir:
 		finally:
 			be.close()
 		assert len(msgs) == 2
-		assert set(['', 'folder1/subfolder']) == set(folders)
+		assert set(['', 'folder1.subfolder']) == set(folders)
 		assert msg_ids == set(['blaa-blaa-1', 'blaa-blaa-3'])
 
 	def test_should_support_unicode_folder_names(self, sample_path, sample_maildir):
@@ -218,15 +218,15 @@ class TestMaildir:
 			be.close()
 
 	def test_folders_should_be_listed(self, sample_path, sample_maildir):
-		f = sample_maildir.add_folder('folder1')
+		sample_maildir.add_folder('folder1')
 		sample_maildir.add_folder('folder2')
-		f.add_folder('subfolder')
+		sample_maildir.add_folder('folder1.subfolder')
 		sample_maildir.close()
 
 		be = create_backend('maildir', path=sample_path)
 		be.open()
 		folders = be.request_folders()
-		assert set(['', 'folder1', 'folder2', 'folder1/subfolder']) == set(folders)
+		assert set(['', 'folder1', 'folder2', 'folder1.subfolder']) == set(folders)
 
 	def test_maildir_does_not_support_notifications(self, sample_path):
 		be = create_backend('maildir', path=sample_path)

--- a/tests/test_backend_local.py
+++ b/tests/test_backend_local.py
@@ -221,6 +221,7 @@ class TestMaildir:
 		f = sample_maildir.add_folder('folder1')
 		sample_maildir.add_folder('folder2')
 		f.add_folder('subfolder')
+		sample_maildir.close()
 
 		be = create_backend('maildir', path=sample_path)
 		be.open()


### PR DESCRIPTION
I made review fixes https://github.com/pulb/mailnag/pull/137. 

I also fixed/simplified (see https://github.com/pulb/mailnag/pull/137#issuecomment-251204016) folder handling to support flat directory structure (as described in maildir specs). Maildir directory structure looks now following:

```
.
├── cur
├── .folder1
│   ├── cur
│   ├── maildirfolder
│   ├── new
│   └── tmp
├── .folder1.subfolder
│   ├── cur
│   ├── maildirfolder
│   ├── new
│   └── tmp
├── .folder2
│   ├── cur
│   ├── maildirfolder
│   ├── new
│   └── tmp
├── new
└── tmp

```
If somebody someday still needs more directory hierarchy, that is not a problem. Each folder is also a maildir, so new Account could be created to directly point to the folder.