### PR TITLE
IMAP specific mutf7 encoding and decoding moved

### DIFF
--- a/Mailnag/backends/__init__.py
+++ b/Mailnag/backends/__init__.py
@@ -41,7 +41,7 @@ def _str_to_folders(folders_str):
 
 
 def _folders_to_str(folders):
-	return json.dumps(folders)
+	return json.dumps(folders, ensure_ascii=False).encode('utf-8')
 
 
 def _str_to_bool(string):

--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -33,6 +33,7 @@ from Mailnag.backends.base import MailboxBackend
 import Mailnag.common.imaplib2 as imaplib
 from Mailnag.common.imaplib2 import AUTH
 from Mailnag.common.exceptions import InvalidOperationException
+from Mailnag.common.mutf7 import encode_mutf7, decode_mutf7
 
 
 class IMAPMailboxBackend(MailboxBackend):
@@ -47,7 +48,7 @@ class IMAPMailboxBackend(MailboxBackend):
 		self.server = server
 		self.port = port
 		self.ssl = ssl # bool
-		self.folders = folders
+		self.folders = [encode_mutf7(folder) for folder in folders]
 		self._conn = None
 
 
@@ -126,7 +127,7 @@ class IMAPMailboxBackend(MailboxBackend):
 				folder = match.group(2)
 				lst.append(folder)
 		
-		return lst
+		return [decode_mutf7(folder) for folder in lst]
 
 
 	def notify_next_change(self, callback=None, timeout=None):

--- a/Mailnag/configuration/accountdialog.py
+++ b/Mailnag/configuration/accountdialog.py
@@ -32,7 +32,6 @@ from Mailnag.common.dist_cfg import PACKAGE_NAME
 from Mailnag.common.i18n import _
 from Mailnag.common.utils import get_data_file, splitstr
 from Mailnag.common.accounts import Account
-from Mailnag.common import mutf7
 
 IDX_GMAIL	= 0
 IDX_GMX		= 1
@@ -172,7 +171,7 @@ class AccountDialog:
 		folders = []
 		for row in self._liststore_folders:
 			if row[0]:
-				folders.append(mutf7.encode_mutf7(row[1].decode('utf-8')))
+				folders.append(row[1].decode('utf-8'))
 		return folders
 	
 	
@@ -284,7 +283,7 @@ class AccountDialog:
 						if f in self._acc.folders:
 							enabled = True
 							self._selected_folder_count += 1
-						row = [enabled, mutf7.decode_mutf7(f)]
+						row = [enabled, f]
 						self._liststore_folders.append(row)
 					
 					# Enable the push checkbox in case a remote folder wasn't found 

--- a/tests/test_common_mutf7.py
+++ b/tests/test_common_mutf7.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# test_account.py
+#
+# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+"""Test cases for mutf7."""
+
+from Mailnag.common.mutf7 import encode_mutf7, decode_mutf7
+
+def test_encode():
+	expected = 'Die Katzen &- die M&AOQ-use'
+	result = encode_mutf7(u'Die Katzen & die Mäuse')
+	assert expected == result
+
+def test_decode():
+	expected = u'Die Katzen & die Mäuse'
+	result = decode_mutf7('Die Katzen &- die M&AOQ-use')
+	assert expected == result
+

--- a/tests/test_common_mutf7.py
+++ b/tests/test_common_mutf7.py
@@ -22,15 +22,22 @@
 
 """Test cases for mutf7."""
 
+import pytest
+
 from Mailnag.common.mutf7 import encode_mutf7, decode_mutf7
 
-def test_encode():
+def test_encode_mutf7():
 	expected = 'Die Katzen &- die M&AOQ-use'
 	result = encode_mutf7(u'Die Katzen & die Mäuse')
 	assert expected == result
 
-def test_decode():
+def test_decode_mutf7():
 	expected = u'Die Katzen & die Mäuse'
 	result = decode_mutf7('Die Katzen &- die M&AOQ-use')
 	assert expected == result
+
+def test_encode_mutf7_with_str_fails():
+	"""Test to document current behaviour: encode_mutf7 requires unicode."""
+	with pytest.raises(Exception):
+		encode_mutf7('Die Katzen & die Mäuse')
 


### PR DESCRIPTION
I moved IMAP specific folder encoding from account dialog to IMAP backend. So backends return now unicode names in requests_folders method and take unicode names from config. Output in account dialog is still same as before.

However, folder names are now encoded differently in config file, since they are now encoded by json.dumps:
`folder = ["INBOX", "Ty\u00f6"]`
I am not sure if this change is a problem. The encoding came from https://github.com/pulb/mailnag/pull/130, and I think there is not yet new release after that. ... or is there? Version number is already updated...