### PR TITLE
Refactorings related to Account class

### DIFF
--- a/Mailnag/backends/base.py
+++ b/Mailnag/backends/base.py
@@ -67,6 +67,11 @@ class MailboxBackend(object):
 		"""
 		raise NotImplementedError
 
+	def supports_notifications(self):
+		"""Returns True if mailbox supports notifications."""
+		# Default implementation
+		return False
+
 	@abstractmethod
 	def notify_next_change(self, callback=None, timeout=None):
 		"""Asks mailbox to notify next change.

--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -40,7 +40,7 @@ class IMAPMailboxBackend(MailboxBackend):
 	"""Implementation of IMAP mail boxes."""
 
 	def __init__(self, name = '', user = '', password = '', oauth2string = '',
-				 server = '', port = '', ssl = True, folders = [], **kw):
+				 server = '', port = '', ssl = True, folders = [], idle=True, **kw):
 		self.name = name
 		self.user = user
 		self.password = password
@@ -49,6 +49,7 @@ class IMAPMailboxBackend(MailboxBackend):
 		self.port = port
 		self.ssl = ssl # bool
 		self.folders = [encode_mutf7(folder) for folder in folders]
+		self.idle = idle
 		self._conn = None
 
 
@@ -129,6 +130,11 @@ class IMAPMailboxBackend(MailboxBackend):
 		
 		return lst
 
+
+	def supports_notifications(self):
+		"""Returns True if mailbox supports notifications.
+		IMAP mailbox supports notifications if idle parameter is True"""
+		return self.idle
 
 	def notify_next_change(self, callback=None, timeout=None):
 		self._ensure_open()

--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -116,6 +116,11 @@ class Account:
 		return self._get_backend().list_messages()
 
 
+	def supports_notifications(self):
+		"""Returns True if account supports notifications."""
+		return self._get_backend().supports_notifications()
+
+
 	def notify_next_change(self, callback=None, timeout=None):
 		"""Asks mailbox to notify next change.
 		Callback is called when new mail arrives or removed.

--- a/Mailnag/daemon/idlers.py
+++ b/Mailnag/daemon/idlers.py
@@ -4,7 +4,7 @@
 # idlers.py
 #
 # Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
-# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+# Copyright 2016, 2018 Timo Kankare <timo.kankare@iki.fi>
 # Copyright 2011 Leighton Earl <leighton.earl@gmx.com>
 #
 # This program is free software; you can redistribute it and/or modify
@@ -136,7 +136,7 @@ class IdlerRunner:
 	
 	def start(self):
 		for acc in self._accounts:
-			if acc.imap and acc.idle:
+			if acc.supports_notifications():
 				try:
 					idler = Idler(acc, self._sync_callback, self._idle_timeout)
 					idler.start()

--- a/Mailnag/daemon/mailnagdaemon.py
+++ b/Mailnag/daemon/mailnagdaemon.py
@@ -150,8 +150,7 @@ class MailnagDaemon:
 		# have been closed already.
 		self._ensure_valid_state()
 		
-		non_idle_accounts = filter(lambda acc: (not acc.imap) or 
-			(acc.imap and not acc.idle), self._accounts)
+		non_idle_accounts = self._get_non_idle_accounts(self._accounts)
 		self._mailchecker.check(non_idle_accounts)
 	
 	
@@ -180,9 +179,8 @@ class MailnagDaemon:
 			except:
 				logging.exception('Caught an exception.')
 
-			idle_accounts = filter(lambda acc: acc.imap and acc.idle, self._accounts)
-			non_idle_accounts = filter(lambda acc: (not acc.imap) or 
-				(acc.imap and not acc.idle), self._accounts)
+			idle_accounts = self._get_idle_accounts(self._accounts)
+			non_idle_accounts = self._get_non_idle_accounts(self._accounts)
 
 			# start polling thread for POP3 accounts and
 			# IMAP accounts without idle support
@@ -232,8 +230,16 @@ class MailnagDaemon:
 			# (see timeout in mailnag.cleanup())
 			# ..but also don't sleep to short in case of a ping connection test.
 			time.sleep(3)
-	
-	
+
+
+	def _get_idle_accounts(self, accounts):
+		return [acc for acc in self._accounts if acc.supports_notifications()]
+
+
+	def _get_non_idle_accounts(self, accounts):
+		return [acc for acc in self._accounts if not acc.supports_notifications()]
+
+
 	def _load_plugins(self, cfg, hookreg, memorizer):
 		class MailnagController_Impl(MailnagController):
 			def __init__(self, daemon, memorizer, hookreg, shutdown_request_hdlr):

--- a/Mailnag/daemon/mails.py
+++ b/Mailnag/daemon/mails.py
@@ -85,8 +85,9 @@ class MailCollector:
 						sender, id, acc))
 					mail_ids[id] = None
 
-			# don't close idle connections
-			if not acc.idle:
+			# leave account with notifications open, so that it can
+			# send notifications about new mails
+			if not acc.supports_notifications():
 				# disconnect from Email-Server
 				acc.close()
 		

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -22,6 +22,8 @@
 
 """Test cases for Account."""
 
+import pytest
+
 from Mailnag.common.accounts import Account
 
 
@@ -108,4 +110,19 @@ def test_account_should_configurable_with_any_parameters():
 	config = account.get_config()
 	assert config['weird'] == 'odd'
 	assert config['odd'] == 'weird'
+
+
+@pytest.mark.parametrize("config,should_support", [
+	({'mailbox_type': 'imap', 'idle': True}, True),
+	({'mailbox_type': 'imap', 'idle': False}, False),
+	({'mailbox_type': 'pop3'}, False),
+	({'mailbox_type': 'mbox'}, False),
+	({'mailbox_type': 'maildir'}, False),
+])
+def test_account_supports_notifications(config, should_support):
+	account = Account(**config)
+	if should_support:
+		assert account.supports_notifications()
+	else:
+		assert not account.supports_notifications()
 


### PR DESCRIPTION
This is refactoring and preparation to get rid of extra attiributes in the Account class. Idle and imap attributes were used here and there to check if an account supports notifications. I added supports_notifications method to the Account and backend classes.