### PR TITLE
Get id fix

### DIFF
--- a/Mailnag/common/accounts.py
+++ b/Mailnag/common/accounts.py
@@ -5,7 +5,7 @@
 #
 # Copyright 2011 - 2017 Patrick Ulbrich <zulu99@gmx.net>
 # Copyright 2016 Thomas Haider <t.haider@deprecate.de>
-# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+# Copyright 2016, 2018 Timo Kankare <timo.kankare@iki.fi>
 # Copyright 2011 Ralf Hersel <ralf.hersel@gmx.net>
 #
 # This program is free software; you can redistribute it and/or modify
@@ -138,11 +138,12 @@ class Account:
 		Returns an empty list if mailbox does not support folders.
 		"""
 		return self._get_backend().request_folders()
-		
-		
+
+
 	def get_id(self):
-		# TODO : this id is not really unique...
-		return str(hash(self.user + self.server + ', '.join(self.folders)))
+		"""Returns unique id for the account."""
+		# Assumption: The name of the account is unique.
+		return str(hash(self.name))
 
 
 	def _get_backend(self):

--- a/Mailnag/daemon/mails.py
+++ b/Mailnag/daemon/mails.py
@@ -4,7 +4,7 @@
 # mails.py
 #
 # Copyright 2011 - 2016 Patrick Ulbrich <zulu99@gmx.net>
-# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+# Copyright 2016, 2018 Timo Kankare <timo.kankare@iki.fi>
 # Copyright 2011 Leighton Earl <leighton.earl@gmx.com>
 # Copyright 2011 Ralf Hersel <ralf.hersel@gmx.net>
 #
@@ -194,7 +194,7 @@ class MailCollector:
 			# subject but *no datetime* will have the same hash id, 
 			# i.e. only the first mail is notified. 
 			# (Should happen very rarely).
-			id = hashlib.md5((acc.server + folder + acc.user + 
+			id = hashlib.md5((acc.get_id() + folder +
 				sender[1] + subject + str(datetime))
 				.encode('utf-8')).hexdigest()
 		

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -2,7 +2,7 @@
 #
 # test_account.py
 #
-# Copyright 2016 Timo Kankare <timo.kankare@iki.fi>
+# Copyright 2016, 2018 Timo Kankare <timo.kankare@iki.fi>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,25 @@
 """Test cases for Account."""
 
 from Mailnag.common.accounts import Account
+
+
+def test_account_get_id_should_be_unique():
+	accounts = [
+		Account(name='a', mailbox_type='imap', enabled=True, user='x', server='xx'),
+		Account(name='b', mailbox_type='pop3', enabled=True, user='y', server='yy'),
+		Account(name='c', mailbox_type='mbox', enabled=True),
+		Account(name='d', mailbox_type='maildir', enabled=True),
+	]
+	ids = set(acc.get_id() for acc in accounts)
+
+	assert len(ids) == len(accounts)
+
+
+def test_account_get_id_should_be_consistent():
+	account = Account(name='a', mailbox_type='imap', enabled=True, user='x', server='xx')
+	expected_id = account.get_id()
+	for i in range(20):
+		assert account.get_id() == expected_id
 
 
 def test_account_should_keep_configuration():


### PR DESCRIPTION
I looked the usage of Account class attributes and noticed that server and user attributes was used in Account.get_id() method and MailCollector._get_id() method. Since not every account (and backend) have those attributes, I changed those to name attribute. I assume that every account has an unique name. Is this correct?