### PR TITLE
try CRAM-MD5 auth if advertised by capabilities, then default to LOGIN

### DIFF
--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -198,6 +198,9 @@ class IMAPMailboxBackend(MailboxBackend):
 				
 			if self.oauth2string != '':
 				conn.authenticate('XOAUTH2', lambda x: self.oauth2string)
+			elif 'AUTH=CRAM-MD5' in conn.capabilities:
+				# use CRAM-MD5 auth if available
+				conn.login_cram_md5(self.user, self.password)
 			else:
 				conn.login(self.user, self.password)
 		except:


### PR DESCRIPTION
This lets mailnag use CRAM-MD5 authentication for IMAP accounts if this advertised by the IMAP server through the capabilities string given on connection.

If CRAM-MD5 is not advertised the standard (plaintext) LOGIN method will be used as it is currently.

As well as being more secure, this also means that if server operators have disabled LOGIN method mailnag can still be used.

