### PR TITLE
libnotifyplugin: Extend check for is_gnome

### DIFF
--- a/Mailnag/plugins/libnotifyplugin.py
+++ b/Mailnag/plugins/libnotifyplugin.py
@@ -64,8 +64,7 @@ class LibNotifyPlugin(Plugin):
 		# initialize Notification
 		if not self._initialized:
 			Notify.init("Mailnag")
-			self._is_gnome = 'GDMSESSION' in os.environ and \
-				(os.environ['GDMSESSION'] == 'gnome')
+			self._is_gnome = self._is_gnome_environment(('GDMSESSION', 'XDG_CURRENT_DESKTOP'))
 			self._initialized = True
 		
 		def mails_added_hook(new_mails, all_mails):
@@ -374,6 +373,13 @@ class LibNotifyPlugin(Plugin):
 		# with the most recent date) is re-notified.
 		# To fix that, simply put new mails on top explicitly.  
 		return new_mails + [m for m in all_mails if m not in new_mails]
+
+
+	def _is_gnome_environment(self, env_vars):
+		for var in env_vars:
+			if os.environ.get(var, '').lower().endswith('gnome'):
+				return True
+		return False
 
 
 def get_default_mail_reader():


### PR DESCRIPTION
Following changes will extend the GNOME environment check in the libnotify plugin:

1) Two env vars are checked instead of one by adding `XDG_CURRENT_DESKTOP`.
2) The check is changed from exact match of "gnome" to a check for the string's ending.

With this the request intends to solve #146 by having a more inclusive check because `GDMSESSION` seems to not be sufficient for identifying if GNOME is used (on my Ubuntu machine the value is just "ubuntu"). `XDG_CURRENT_DESKTOP` seems to have needed info on most environments: On Ubuntu it is "ubuntu:GNOME", on Budgie "Budgie:GNOME" and on Fedora "GNOME-Classic:GNOME". This is why a check for `endswith('gnome')` should account for most cases.