### PR TITLE
logging: include "mailnag" and default to WARNING level

### DIFF
--- a/Mailnag/common/utils.py
+++ b/Mailnag/common/utils.py
@@ -28,7 +28,7 @@ import inspect
 
 from Mailnag.common.dist_cfg import PACKAGE_NAME, DBUS_BUS_NAME, DBUS_OBJ_PATH
 
-LOG_FORMAT = '%(levelname)s (%(asctime)s): %(message)s'
+LOG_FORMAT = 'mailnag[%(process)d]: %(levelname)s (%(asctime)s): %(message)s'
 LOG_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 

--- a/mailnag
+++ b/mailnag
@@ -43,7 +43,7 @@ from Mailnag.common.exceptions import InvalidOperationException
 from Mailnag.daemon.mailnagdaemon import MailnagDaemon
 
 PROGNAME = 'mailnag'
-LOG_LEVEL = logging.DEBUG
+LOG_LEVEL = logging.WARNING
 
 
 def cleanup(daemon):

--- a/mailnag-config
+++ b/mailnag-config
@@ -35,7 +35,7 @@ from Mailnag.common.utils import set_procname, shutdown_existing_instance, get_d
 from Mailnag.common.dist_cfg import BIN_DIR
 from Mailnag.configuration.configwindow import ConfigWindow
 
-LOG_LEVEL = logging.DEBUG
+LOG_LEVEL = logging.WARNING
 
 
 class App(Gtk.Application):


### PR DESCRIPTION
This is one way to address the questions raised in Issue #227.  Let me know what you think.  I'd also be inclined to remove the timestamp, and am happy to make that change as well if you'd like.  One could also consider adding `-v/--verbose` which triggers INFO level and `--debug` which triggers DEBUG level.

Closes #227 
