### PR TITLE
Change secret schema type to avoid no password prompt

### DIFF
--- a/Mailnag/common/secretstore.py
+++ b/Mailnag/common/secretstore.py
@@ -37,7 +37,7 @@ class SecretStore():
 			raise _libsecret_err
 	        
 		self._schema = Secret.Schema.new(
-			f'com.github.pulb.{PACKAGE_NAME}', Secret.SchemaFlags.NONE,
+			f'com.github.pulb.{PACKAGE_NAME}', Secret.SchemaFlags.DONT_MATCH_NAME,
 			{'id' : Secret.SchemaAttributeType.STRING})
 
 


### PR DESCRIPTION
As shown in #213, mailnag won't authenticate on first start. The reason
can be found in https://gitlab.gnome.org/GNOME/libsecret/-/issues/7. It
is because that when creating schema using `Secret.SchemaFlags.NONE`.
The schema name is sent as attribute to match (`xdg:schema`). However,
for gnome-keyring side, when the secret is locked. The secret will have
extra attributes which makes that the lookup fails. And use
`Secret.Schema.Flags.DONT_MATCH_NAME` flag creates the schema can avoid
this situation.

However, there is also another situation, just make the schema name to
be `None`, which would be `org.freedesktop.Secret.Generic` schema, which
means no schema at all, so any attributes can be used. So the
`password_lookpup_sync` can also success to allow the password prompt.

This PR adopts the first solution, simply change the FLAG.

Closes #213

---

When using `secret-tool search --all xdg:schema org.freedesktop.Secret.Generic`. The following picture illustrates partial result.

![image](https://user-images.githubusercontent.com/56911263/154984353-ecca4249-ec6f-4ee6-bac0-c1b0f5cf240d.png)

We can see that `gnome-keyring` add attribute `attribute.gkr:compat:hashed:xdg:schema` and there are two original attributes `account` and `service`. When the secret is locked. The attributes become `attribute.gkr:compat:hashed:account` and `attribute.gkr:compat:hashed:service`. And when executing the command `secret-tool search --all xdg:schema com.github.pulb.mailnag`, the result is:

![image](https://user-images.githubusercontent.com/56911263/154984863-b7200f46-b121-4dce-93df-e9f945b2e4a8.png)

There would be no actions.

The reason can be found in https://gitlab.gnome.org/GNOME/libsecret/-/issues/7.


