### PR TITLE
Python 3.12 and assorted fixes

### DIFF
--- a/Mailnag/backends/imap.py
+++ b/Mailnag/backends/imap.py
@@ -148,7 +148,7 @@ class IMAPMailboxBackend(MailboxBackend):
 						if folder != last_folder:
 							conn.select(f'"{folder}"', readonly = False)
 							last_folder = folder
-						status, data = conn.uid("STORE", m.flags['uid'], "+FLAGS", "(\Seen)")
+						status, data = conn.uid("STORE", m.flags['uid'], "+FLAGS", r"(\Seen)")
 					except:
 						logging.warning("Failed to set mail with uid %s to seen on server (account: '%s').", m.flags['uid'], acc.name)
 

--- a/Mailnag/common/imaplib2.py
+++ b/Mailnag/common/imaplib2.py
@@ -2466,7 +2466,7 @@ if __name__ == '__main__':
     ('select', ('imaplib2_test2',)),
     ('search', (None, 'SUBJECT', '"IMAP4 test"')),
     ('fetch', ('1:*', '(FLAGS INTERNALDATE RFC822)')),
-    ('store', ('1', 'FLAGS', '(\Deleted)')),
+    ('store', ('1', 'FLAGS', r'(\Deleted)')),
     ('namespace', ()),
     ('expunge', ()),
     ('recent', ()),
@@ -2571,7 +2571,7 @@ if __name__ == '__main__':
             if not uid: continue
             run('uid', ('FETCH', uid[-1],
                     '(FLAGS INTERNALDATE RFC822.SIZE RFC822.HEADER RFC822.TEXT)'))
-            run('uid', ('STORE', uid[-1], 'FLAGS', '(\Deleted)'))
+            run('uid', ('STORE', uid[-1], 'FLAGS', r'(\Deleted)'))
             run('expunge', ())
 
         if 'IDLE' in M.capabilities:
@@ -2585,10 +2585,10 @@ if __name__ == '__main__':
             dat = run('fetch', (num, '(FLAGS INTERNALDATE RFC822)'), cb=False)
             M._mesg('fetch %s => %s' % (num, repr(dat)))
             run('idle', (2,))
-            run('store', (num, '-FLAGS', '(\Seen)'), cb=False),
+            run('store', (num, '-FLAGS', r'(\Seen)'), cb=False),
             dat = run('fetch', (num, '(FLAGS INTERNALDATE RFC822)'), cb=False)
             M._mesg('fetch %s => %s' % (num, repr(dat)))
-            run('uid', ('STORE', num, 'FLAGS', '(\Deleted)'))
+            run('uid', ('STORE', num, 'FLAGS', r'(\Deleted)'))
             run('expunge', ())
             if idle_intr:
                 M._mesg('HIT CTRL-C to interrupt IDLE')

--- a/Mailnag/common/imaplib2.py
+++ b/Mailnag/common/imaplib2.py
@@ -309,6 +309,7 @@ class IMAP4(object):
         self.compressor = None          # COMPRESS/DEFLATE if not None
         self.decompressor = None
         self._tls_established = False
+        self._ssl_context = None
 
         # Create unique tag for this session,
         # and compile tagged response matcher.
@@ -492,7 +493,13 @@ class IMAP4(object):
 
             ssl_version =  TLS_MAP[self.tls_level][self.ssl_version]
 
-            self.sock = ssl.wrap_socket(self.sock, self.keyfile, self.certfile, ca_certs=self.ca_certs, cert_reqs=cert_reqs, ssl_version=ssl_version, ciphers='ALL')
+            self._ssl_context = ssl.SSLContext(ssl_version)
+            self._ssl_context.verify_mode = cert_reqs
+            if self.ca_certs:
+                self._ssl_context.load_verify_locations(self.ca_certs)
+            if self.keyfile and self.certfile:
+                self._ssl_context.load_cert_chain(self.certfile, self.keyfile)
+            self.sock = self._ssl_context.wrap_socket(self.sock, server_hostname=self.host)
             ssl_exc = ssl.SSLError
             self.read_fd = self.sock.fileno()
         except ImportError:

--- a/Mailnag/common/imaplib2.py
+++ b/Mailnag/common/imaplib2.py
@@ -492,7 +492,7 @@ class IMAP4(object):
 
             ssl_version =  TLS_MAP[self.tls_level][self.ssl_version]
 
-            self.sock = ssl.wrap_socket(self.sock, self.keyfile, self.certfile, ca_certs=self.ca_certs, cert_reqs=cert_reqs, ssl_version=ssl_version)
+            self.sock = ssl.wrap_socket(self.sock, self.keyfile, self.certfile, ca_certs=self.ca_certs, cert_reqs=cert_reqs, ssl_version=ssl_version, ciphers='ALL')
             ssl_exc = ssl.SSLError
             self.read_fd = self.sock.fileno()
         except ImportError:

--- a/Mailnag/configuration/configwindow.py
+++ b/Mailnag/configuration/configwindow.py
@@ -245,7 +245,12 @@ class ConfigWindow:
 		if not os.path.exists(autostart_folder):
 			os.makedirs(autostart_folder)
 
-		shutil.copyfile(src, dst)
+		try:
+			shutil.copyfile(src, dst)
+		except Exception as e:
+			import logging
+			logging.info(f"failed setting autostart: {e}")
+			return
 		
 		# If mailag-config was started from a local directory, 
 		# patch the exec path of the autostart .desktop file accordingly.


### PR DESCRIPTION
This PR makes the app work for python 3.12. It incorporates the fix from https://github.com/pulb/mailnag/issues/245#issuecomment-1753068005. Closes:
- [x] #244
- [x] #245

Some other improvements:

#### Fix SSLV3_ALERT_HANDSHAKE_FAILURE for some imap servers

Connections to some imap servers (e.g. imap.pku.edu.cn) fail after upgrading to python 3.10. This is because they use old, less secure ciphers that are disabled for Python 3.10. In order to connect to those servers, we have to allow more ssl ciphers in imaplib2 for Python 3.10. See:

1. https://stackoverflow.com/a/71007463
2. https://www.openssl.org/docs/manmaster/man1/openssl-ciphers.html#CIPHER-LIST-FORMAT

#### Also,
- Exit gracefully when autostart creation fails
- Use raw strings for backlashes